### PR TITLE
Handle custom errors from subtensor

### DIFF
--- a/bittensor_cli/src/bittensor/extrinsics/registration.py
+++ b/bittensor_cli/src/bittensor/extrinsics/registration.py
@@ -614,7 +614,10 @@ async def register_extrinsic(
                         if not await response.is_success:
                             success, err_msg = (
                                 False,
-                                format_error_message(await response.error_message),
+                                format_error_message(
+                                    await response.error_message,
+                                    substrate=subtensor.substrate,
+                                ),
                             )
 
                     if not success:
@@ -785,7 +788,8 @@ async def run_faucet_extrinsic(
             await response.process_events()
             if not await response.is_success:
                 err_console.print(
-                    f":cross_mark: [red]Failed[/red]: {format_error_message(await response.error_message)}"
+                    f":cross_mark: [red]Failed[/red]: "
+                    f"{format_error_message(await response.error_message, subtensor.substrate)}"
                 )
                 if attempts == max_allowed_attempts:
                     raise MaxAttemptsException

--- a/bittensor_cli/src/bittensor/extrinsics/root.py
+++ b/bittensor_cli/src/bittensor/extrinsics/root.py
@@ -36,6 +36,7 @@ from bittensor_cli.src.bittensor.utils import (
     err_console,
     u16_normalized_float,
     print_verbose,
+    format_error_message
 )
 
 if TYPE_CHECKING:
@@ -481,7 +482,6 @@ async def set_root_weights_extrinsic(
             )
 
             success, error_message = await _do_set_weights()
-            console.print(success, error_message)
 
             if not wait_for_finalization and not wait_for_inclusion:
                 return True
@@ -490,7 +490,8 @@ async def set_root_weights_extrinsic(
                 console.print(":white_heavy_check_mark: [green]Finalized[/green]")
                 return True
             else:
-                err_console.print(f":cross_mark: [red]Failed[/red]: {error_message}")
+                fmt_err = format_error_message(error_message, subtensor.substrate)
+                err_console.print(f":cross_mark: [red]Failed[/red]: {fmt_err}")
                 return False
 
     except Exception as e:

--- a/bittensor_cli/src/bittensor/extrinsics/root.py
+++ b/bittensor_cli/src/bittensor/extrinsics/root.py
@@ -418,13 +418,13 @@ async def set_root_weights_extrinsic(
         else:
             return False, await response.error_message
 
-    # my_uid = await subtensor.substrate.query(
-    #     "SubtensorModule", "Uids", [0, wallet.hotkey.ss58_address]
-    # )
-    #
-    # if my_uid is None:
-    #     err_console.print("Your hotkey is not registered to the root network")
-    #     return False
+    my_uid = await subtensor.substrate.query(
+        "SubtensorModule", "Uids", [0, wallet.hotkey.ss58_address]
+    )
+
+    if my_uid is None:
+        err_console.print("Your hotkey is not registered to the root network")
+        return False
 
     try:
         wallet.unlock_coldkey()

--- a/bittensor_cli/src/bittensor/extrinsics/transfer.py
+++ b/bittensor_cli/src/bittensor/extrinsics/transfer.py
@@ -3,6 +3,7 @@ import asyncio
 from bittensor_wallet import Wallet
 from bittensor_wallet.errors import KeyFileError
 from rich.prompt import Confirm
+from substrateinterface.exceptions import SubstrateRequestException
 
 from bittensor_cli.src import NETWORK_EXPLORER_MAP
 from bittensor_cli.src.bittensor.balances import Balance
@@ -59,11 +60,11 @@ async def transfer_extrinsic(
             payment_info = await subtensor.substrate.get_payment_info(
                 call=call, keypair=wallet.coldkeypub
             )
-        except Exception as e:
+        except SubstrateRequestException as e:
             payment_info = {"partialFee": int(2e7)}  # assume  0.02 Tao
             err_console.print(
                 f":cross_mark: [red]Failed to get payment info[/red]:[bold white]\n"
-                f"  {e}[/bold white]\n"
+                f"  {format_error_message(e, subtensor.substrate)}[/bold white]\n"
                 f"  Defaulting to default transfer fee: {payment_info['partialFee']}"
             )
 

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -927,7 +927,9 @@ class SubtensorInterface:
             if await response.is_success:
                 return True, ""
             else:
-                return False, format_error_message(await response.error_message)
+                return False, format_error_message(
+                    await response.error_message, substrate=self.substrate
+                )
         except SubstrateRequestException as e:
             return False, e
 

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -961,7 +961,7 @@ class SubtensorInterface:
             else:
                 return True, [], ""
         except SubstrateRequestException as e:
-            return False, [], str(e)
+            return False, [], format_error_message(e, self.substrate)
 
     async def get_subnet_hyperparameters(
         self, netuid: int, block_hash: Optional[str] = None

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -931,7 +931,7 @@ class SubtensorInterface:
                     await response.error_message, substrate=self.substrate
                 )
         except SubstrateRequestException as e:
-            return False, e
+            return False, format_error_message(e, substrate=self.substrate)
 
     async def get_children(self, hotkey, netuid) -> tuple[bool, list, str]:
         """

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -453,7 +453,7 @@ def get_explorer_url_for_network(
 
 
 def format_error_message(
-    error_message: Union[dict, Exception, str], substrate: "AsyncSubstrateInterface"
+    error_message: Union[dict, Exception], substrate: "AsyncSubstrateInterface"
 ) -> str:
     """
     Formats an error message from the Subtensor error information for use in extrinsics.
@@ -472,18 +472,24 @@ def format_error_message(
 
     if isinstance(error_message, Exception):
         # generally gotten through SubstrateRequestException args
+        new_error_message = None
         for arg in error_message.args:
             try:
                 d = ast.literal_eval(arg)
                 if isinstance(d, dict):
                     if "error" in d:
-                        error_message = d["error"]
+                        new_error_message = d["error"]
                         break
                     elif all(x in d for x in ["code", "message", "data"]):
-                        error_message = d
+                        new_error_message = d
                         break
             except ValueError:
                 pass
+        if new_error_message is None:
+            return_val = " ".join(error_message.args)
+            return f"Subtensor returned: {return_val}"
+        else:
+            error_message = new_error_message
 
     if isinstance(error_message, dict):
         # subtensor error structure
@@ -525,9 +531,6 @@ def format_error_message(
             err_name = error_message.get("name", err_name)
             err_docs = error_message.get("docs", [err_description])
             err_description = err_docs[0] if err_docs else err_description
-    elif isinstance(error_message, str):
-        # allows for passing str errors to this function
-        return f"Subtensor returned: {error_message}"
 
     return f"Subtensor returned `{err_name}({err_type})` error. This means: `{err_description}`."
 

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -26,6 +26,9 @@ from bittensor_cli.src.bittensor.balances import Balance
 
 if TYPE_CHECKING:
     from bittensor_cli.src.bittensor.chain_data import SubnetHyperparameters
+    from bittensor_cli.src.bittensor.async_substrate_interface import (
+        AsyncSubstrateInterface,
+    )
 
 console = Console()
 err_console = Console(stderr=True)
@@ -448,24 +451,65 @@ def get_explorer_url_for_network(
     return explorer_urls
 
 
-def format_error_message(error_message: dict) -> str:
+def format_error_message(
+    error_message: dict, substrate: "AsyncSubstrateInterface"
+) -> str:
     """
-    Formats an error message from the Subtensor error information to using in extrinsics.
+    Formats an error message from the Subtensor error information for use in extrinsics.
 
-    :param error_message: A dictionary containing the error information from Subtensor.
+    Args:
+        error_message: A dictionary containing the error information from Subtensor.
+        substrate: The substrate interface to use.
 
-    :return: A formatted error message string.
+    Returns:
+        str: A formatted error message string.
     """
-    err_type = "UnknownType"
     err_name = "UnknownError"
+    err_type = "UnknownType"
     err_description = "Unknown Description"
 
     if isinstance(error_message, dict):
-        err_type = error_message.get("type", err_type)
-        err_name = error_message.get("name", err_name)
-        err_docs = error_message.get("docs", [])
-        err_description = err_docs[0] if len(err_docs) > 0 else err_description
-    return f"Subtensor returned `{err_name} ({err_type})` error. This means: `{err_description}`"
+        # subtensor error structure
+        if (
+            error_message.get("code")
+            and error_message.get("message")
+            and error_message.get("data")
+        ):
+            err_name = "SubstrateRequestException"
+            err_type = error_message.get("message", "")
+            err_data = error_message.get("data", "")
+
+            # subtensor custom error marker
+            if err_data.startswith("Custom error:") and substrate:
+                if substrate.metadata:
+                    try:
+                        pallet = substrate.metadata.get_metadata_pallet(
+                            "SubtensorModule"
+                        )
+                        error_index = int(err_data.split("Custom error:")[-1])
+
+                        error_dict = pallet.errors[error_index].value
+                        err_type = error_dict.get("message", err_type)
+                        err_docs = error_dict.get("docs", [])
+                        err_description = err_docs[0] if err_docs else err_description
+                    except AttributeError:
+                        err_console.print(
+                            "Substrate pallets data unavailable. This is usually caused by an uninitialized substrate."
+                        )
+            else:
+                err_description = err_data
+
+        elif (
+            error_message.get("type")
+            and error_message.get("name")
+            and error_message.get("docs")
+        ):
+            err_type = error_message.get("type", err_type)
+            err_name = error_message.get("name", err_name)
+            err_docs = error_message.get("docs", [err_description])
+            err_description = err_docs[0] if err_docs else err_description
+
+    return f"Subtensor returned `{err_name}({err_type})` error. This means: `{err_description}`."
 
 
 def convert_blocks_to_time(blocks: int, block_time: int = 12) -> tuple[int, int, int]:

--- a/bittensor_cli/src/commands/stake/children_hotkeys.py
+++ b/bittensor_cli/src/commands/stake/children_hotkeys.py
@@ -18,6 +18,7 @@ from bittensor_cli.src.bittensor.utils import (
     u16_to_float,
     u64_to_float,
     is_valid_ss58_address,
+    format_error_message,
 )
 
 
@@ -208,8 +209,11 @@ async def set_childkey_take_extrinsic(
                 # )
                 return False, error_message
 
-        except Exception as e:
-            return False, f"Exception occurred while setting childkey take: {str(e)}"
+        except SubstrateRequestException as e:
+            return (
+                False,
+                f"Exception occurred while setting childkey take: {format_error_message(e, subtensor.substrate)}",
+            )
 
 
 async def get_childkey_take(subtensor, hotkey: str, netuid: int) -> Optional[int]:
@@ -232,7 +236,9 @@ async def get_childkey_take(subtensor, hotkey: str, netuid: int) -> Optional[int
             return int(childkey_take_.value)
 
     except SubstrateRequestException as e:
-        err_console.print(f"Error querying ChildKeys: {e}")
+        err_console.print(
+            f"Error querying ChildKeys: {format_error_message(e, subtensor.substrate)}"
+        )
         return None
 
 

--- a/bittensor_cli/src/commands/subnets.py
+++ b/bittensor_cli/src/commands/subnets.py
@@ -129,7 +129,7 @@ async def register_subnetwork_extrinsic(
         await response.process_events()
         if not await response.is_success:
             err_console.print(
-                f":cross_mark: [red]Failed[/red]: {format_error_message(await response.error_message)}"
+                f":cross_mark: [red]Failed[/red]: {format_error_message(await response.error_message, substrate)}"
             )
             await asyncio.sleep(0.5)
             return False

--- a/bittensor_cli/src/commands/weights.py
+++ b/bittensor_cli/src/commands/weights.py
@@ -266,7 +266,9 @@ class SetWeightsExtrinsic:
             if await response.is_success:
                 return True, "Successfully set weights."
             else:
-                return False, format_error_message(await response.error_message)
+                return False, format_error_message(
+                    await response.error_message, self.subtensor.substrate
+                )
 
         with console.status(
             f":satellite: Setting weights on [white]{self.subtensor.network}[/white] ..."
@@ -327,7 +329,9 @@ class SetWeightsExtrinsic:
             else:
                 success, error_message = (
                     False,
-                    format_error_message(await response.error_message),
+                    format_error_message(
+                        await response.error_message, self.subtensor.substrate
+                    ),
                 )
 
         if success:


### PR DESCRIPTION
Ported from https://github.com/opentensor/bittensor/pull/2305

In addition to catching the typical error messages we receive, we now also catch errors embedded in `SubstrateRequestException`s by catching these exceptions explicitly and parsing the literal dicts out of the args.

E.g. `AsyncSubstrateInterface.submit_extrinsic` can raise a `SubstrateRequestException` in two ways:

A.
```py
responses = (
    await self._make_rpc_request(
        [
            self.make_payload(
                "rpc_request",
                "author_submitAndWatchExtrinsic",
                [str(extrinsic.data)],
            )
        ],
        result_handler=result_handler,
    )
)["rpc_request"]
response = next(
    (r for r in responses if "block_hash" in r and "extrinsic_hash" in r),
    None,
)

if not response:
    raise SubstrateRequestException(responses)
```
which dumps a number of dict-like responses to the `SubstrateRequestException`'s args.

or:

B.
```py
if "result" not in response:
    raise SubstrateRequestException(response.get("error"))
```
which dumps the error dict to the `SubstrateRequestException`'s args.

We handle this in both cases by parsing the `SubstrateRequestException.args`:
```py
if isinstance(error_message, Exception):
    # generally gotten through SubstrateRequestException args
    new_error_message = None
    for arg in error_message.args:
        try:
            d = ast.literal_eval(arg)
            if isinstance(d, dict):
                if "error" in d:  # case A
                    new_error_message = d["error"]
                    break
                elif all(x in d for x in ["code", "message", "data"]):  # case B
                    new_error_message = d
                    break
        except ValueError:
            pass
    if new_error_message is None:  # case C
        return_val = " ".join(error_message.args)
        return f"Subtensor returned: {return_val}"
    else:
        error_message = new_error_message
```

This also allows us to handle the majority of raised `SubstrateRequestException` args which have a single string with the message included (case C).