### PR TITLE
Give user their UID immediately after root/sn registration.

### DIFF
--- a/bittensor_cli/src/bittensor/extrinsics/registration.py
+++ b/bittensor_cli/src/bittensor/extrinsics/registration.py
@@ -440,7 +440,6 @@ async def is_hotkey_registered(
         params=[netuid, hotkey_ss58],
     )
     if _result is not None:
-        print(_result)
         return True
     else:
         return False

--- a/bittensor_cli/src/bittensor/extrinsics/root.py
+++ b/bittensor_cli/src/bittensor/extrinsics/root.py
@@ -340,17 +340,22 @@ async def root_register_extrinsic(
 
         # Successful registration, final check for neuron and pubkey
         else:
-            is_registered = await is_hotkey_registered(
-                subtensor, netuid=0, hotkey_ss58=wallet.hotkey.ss58_address
+            uid = await subtensor.substrate.query(
+                module="SubtensorModule",
+                storage_function="Uids",
+                params=[0, wallet.hotkey.ss58_address],
             )
-            if is_registered:
-                console.print(":white_heavy_check_mark: [green]Registered[/green]")
+            if uid is not None:
+                console.print(
+                    f":white_heavy_check_mark: [green]Registered with UID {uid}[/green]"
+                )
                 return True
             else:
                 # neuron not found, try again
                 err_console.print(
                     ":cross_mark: [red]Unknown error. Neuron not found.[/red]"
                 )
+                return False
 
 
 async def set_root_weights_extrinsic(

--- a/bittensor_cli/src/commands/root.py
+++ b/bittensor_cli/src/commands/root.py
@@ -332,7 +332,7 @@ async def burned_register_extrinsic(
     else:
         with console.status(":satellite: Checking Balance...", spinner="aesthetic"):
             block_hash = await subtensor.substrate.get_chain_head()
-            new_balance, netuids_for_hotkey = await asyncio.gather(
+            new_balance, netuids_for_hotkey, my_uid = await asyncio.gather(
                 subtensor.get_balance(
                     wallet.coldkeypub.ss58_address,
                     block_hash=block_hash,
@@ -340,6 +340,9 @@ async def burned_register_extrinsic(
                 ),
                 subtensor.get_netuids_for_hotkey(
                     wallet.hotkey.ss58_address, block_hash=block_hash
+                ),
+                subtensor.substrate.query(
+                    "SubtensorModule", "Uids", [netuid, wallet.hotkey.ss58_address]
                 ),
             )
 
@@ -349,7 +352,9 @@ async def burned_register_extrinsic(
         )
 
         if len(netuids_for_hotkey) > 0:
-            console.print(":white_heavy_check_mark: [green]Registered[/green]")
+            console.print(
+                f":white_heavy_check_mark: [green]Registered on netuid {netuid} with UID {my_uid}[/green]"
+            )
             return True
         else:
             # neuron not found, try again


### PR DESCRIPTION
Gives the user their UID at the completion of `btcli root register` and `btcli subnets register`