### PR TITLE
Adds improvements and minor fixes

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -179,9 +179,9 @@ class Options:
     prompt = typer.Option(
         True,
         "--prompt/--no-prompt",
-        "--no/--yes",
+        " /--yes",
         "--prompt/--no_prompt",
-        "-n/-y",
+        " /-y",
         help="Enable or disable interactive prompts.",
     )
     verbose = typer.Option(
@@ -866,7 +866,6 @@ class CLIManager:
         }
         bools = ["use_cache"]
         if all(v is None for v in args.values()):
-            
             # Print existing configs
             self.get_config()
 

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -101,7 +101,7 @@ class Options:
         None,
         "--json",
         "-j",
-        help="Path to a JSON file containing the encrypted key backup. For example, a JSON file from PolkadotJS.)",
+        help="Path to a JSON file containing the encrypted key backup. For example, a JSON file from PolkadotJS.",
     )
     json_password = typer.Option(
         None, "--json-password", help="Password to decrypt the JSON file."
@@ -1712,7 +1712,12 @@ class CLIManager:
         wallet_name: Optional[str] = Options.wallet_name,
         wallet_path: Optional[str] = Options.wallet_path,
         wallet_hotkey: Optional[str] = Options.wallet_hotkey,
-        n_words: Optional[int] = None,
+        n_words: Optional[int] = typer.Option(
+            None,
+            "--n-words",
+            "--n_words",
+            help="The number of words used in the mnemonic. Options: [12, 15, 18, 21, 24]",
+        ),
         use_password: bool = typer.Option(
             False,  # Overriden to False
             help="Set to 'True' to protect the generated Bittensor key with a password.",
@@ -1763,7 +1768,12 @@ class CLIManager:
         wallet_name: Optional[str] = Options.wallet_name,
         wallet_path: Optional[str] = Options.wallet_path,
         wallet_hotkey: Optional[str] = Options.wallet_hotkey,
-        n_words: Optional[int] = None,
+        n_words: Optional[int] = typer.Option(
+            None,
+            "--n-words",
+            "--n_words",
+            help="The number of words used in the mnemonic. Options: [12, 15, 18, 21, 24]",
+        ),
         use_password: Optional[bool] = Options.use_password,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
@@ -3094,23 +3104,15 @@ class CLIManager:
             and not hotkey_ss58_address
         ):
             hotkey_or_ss58 = Prompt.ask(
-                "Do you want to stake to a specific [blue]ss58 address[/blue] or a registered [red]wallet hotkey[/red]?\n"
-                "[Enter '[blue]ss58[/blue]' for an address or '[red]hotkey[/red]' for a wallet hotkey] (default is '[red]hotkey[/red]')",
-                choices=["ss58", "hotkey"],
-                default="hotkey",
-                show_choices=False,
-                show_default=False,
+                "Enter the [blue]hotkey[/blue] name or [blue]ss58 address[/blue] to stake to",
             )
-            if hotkey_or_ss58 == "ss58":
-                hotkey_ss58_address = typer.prompt("Enter the ss58 address to stake to")
-                if not is_valid_ss58_address(hotkey_ss58_address):
-                    print_error("The entered ss58 address is incorrect")
-                    raise typer.Exit()
-                else:
-                    wallet = self.wallet_ask(
-                        wallet_name, wallet_path, wallet_hotkey, ask_for=[WO.NAME]
-                    )
+            if is_valid_ss58_address(hotkey_or_ss58):
+                hotkey_ss58_address = hotkey_or_ss58
+                wallet = self.wallet_ask(
+                    wallet_name, wallet_path, wallet_hotkey, ask_for=[WO.NAME]
+                )
             else:
+                wallet_hotkey = hotkey_or_ss58
                 wallet = self.wallet_ask(
                     wallet_name,
                     wallet_path,
@@ -3257,27 +3259,15 @@ class CLIManager:
             and not include_hotkeys
         ):
             hotkey_or_ss58 = Prompt.ask(
-                "Do you want to unstake from a specific [blue]ss58 address[/blue] or a registered [red]wallet hotkey"
-                "[/red]?\n"
-                "[Enter '[blue]ss58[/blue]' for an address or '[red]hotkey[/red]' for a wallet hotkey] (default is "
-                "'[red]hotkey[/red]')",
-                choices=["ss58", "hotkey"],
-                default="hotkey",
-                show_choices=False,
-                show_default=False,
+                "Enter the [blue]hotkey[/blue] name or [blue]ss58 address[/blue] to unstake from"
             )
-            if hotkey_or_ss58 == "ss58":
-                hotkey_ss58_address = typer.prompt(
-                    "Enter the ss58 address to unstake from"
+            if is_valid_ss58_address(hotkey_or_ss58):
+                hotkey_ss58_address = hotkey_or_ss58
+                wallet = self.wallet_ask(
+                    wallet_name, wallet_path, wallet_hotkey, ask_for=[WO.NAME]
                 )
-                if not is_valid_ss58_address(hotkey_ss58_address):
-                    print_error("The entered ss58 address is incorrect")
-                    raise typer.Exit()
-                else:
-                    wallet = self.wallet_ask(
-                        wallet_name, wallet_path, wallet_hotkey, ask_for=[WO.NAME]
-                    )
             else:
+                wallet_hotkey = hotkey_or_ss58
                 wallet = self.wallet_ask(
                     wallet_name,
                     wallet_path,

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -6,6 +6,7 @@ import re
 import sys
 from pathlib import Path
 from typing import Coroutine, Optional
+from dataclasses import fields
 
 import rich
 import typer
@@ -16,7 +17,6 @@ from rich import box
 from rich.prompt import Confirm, FloatPrompt, Prompt, IntPrompt
 from rich.table import Column, Table
 from bittensor_cli.src import (
-    HYPERPARAMS,
     defaults,
     HELP_PANELS,
     WalletOptions as WO,
@@ -30,6 +30,7 @@ from bittensor_cli.src.commands import root, subnets, sudo, wallets
 from bittensor_cli.src.commands import weights as weights_cmds
 from bittensor_cli.src.commands.stake import children_hotkeys, stake
 from bittensor_cli.src.bittensor.subtensor_interface import SubtensorInterface
+from bittensor_cli.src.bittensor.chain_data import SubnetHyperparameters
 from bittensor_cli.src.bittensor.utils import (
     console,
     err_console,
@@ -140,8 +141,9 @@ class Options:
     netuids = typer.Option(
         None,
         "--netuids",
+        "--netuid",
         "-n",
-        help="Set the netuid(s) to filter by. Separate multiple netuids with a comma, for example: `-n 0,1,2`.",
+        help="Set the netuid(s) to exclude. Separate multiple netuids with a comma, for example: `-n 0,1,2`.",
     )
     netuid = typer.Option(
         None,
@@ -177,6 +179,9 @@ class Options:
     prompt = typer.Option(
         True,
         "--prompt/--no-prompt",
+        "--no/--yes",
+        "--prompt/--no_prompt",
+        "-n/-y",
         help="Enable or disable interactive prompts.",
     )
     verbose = typer.Option(
@@ -861,10 +866,23 @@ class CLIManager:
         }
         bools = ["use_cache"]
         if all(v is None for v in args.values()):
-            arg = Prompt.ask(
-                "Which config setting would you like to update?",
-                choices=list(args.keys()),
+            
+            # Print existing configs
+            self.get_config()
+
+            # Create numbering to choose from
+            config_keys = list(args.keys())
+            console.print("Which config setting would you like to update?\n")
+            for idx, key in enumerate(config_keys, start=1):
+                console.print(f"{idx}. {key}")
+
+            choice = IntPrompt.ask(
+                "\nEnter the [bold]number[/bold] of the config setting you want to update",
+                choices=[str(i) for i in range(1, len(config_keys) + 1)],
+                show_choices=False,
             )
+            arg = config_keys[choice - 1]
+
             if arg in bools:
                 nc = Confirm.ask(
                     f"What value would you like to assign to [red]{arg}[/red]?",
@@ -1721,6 +1739,11 @@ class CLIManager:
         """
         self.verbosity_handler(quiet, verbose)
 
+        if not wallet_name:
+            wallet_name = Prompt.ask(
+                "Enter the wallet name", default=defaults.wallet.name
+            )
+
         if not wallet_hotkey:
             wallet_hotkey = Prompt.ask(
                 "Enter the name of the new hotkey", default=defaults.wallet.hotkey
@@ -2173,7 +2196,13 @@ class CLIManager:
         wallet_name: str = Options.wallet_name,
         wallet_path: str = Options.wallet_path,
         wallet_hotkey: str = Options.wallet_hotkey,
-        netuids: str = Options.netuids,
+        netuids=typer.Option(
+            None,
+            "--netuids",
+            "--netuid",
+            "-n",
+            help="Set the netuid(s) to set weights to. Separate multiple netuids with a comma, for example: `-n 0,1,2`.",
+        ),
         weights: str = Options.weights,
         prompt: bool = Options.prompt,
         quiet: bool = Options.quiet,
@@ -3067,7 +3096,7 @@ class CLIManager:
         ):
             hotkey_or_ss58 = Prompt.ask(
                 "Do you want to stake to a specific [blue]ss58 address[/blue] or a registered [red]wallet hotkey[/red]?\n"
-                "[Enter '[blue]ss58[/blue]' for an address or '[red]hotkey[/red]' for a wallet hotkey] (default is '[blue]ss58[/blue]')",
+                "[Enter '[blue]ss58[/blue]' for an address or '[red]hotkey[/red]' for a wallet hotkey] (default is '[red]hotkey[/red]')",
                 choices=["ss58", "hotkey"],
                 default="hotkey",
                 show_choices=False,
@@ -3232,9 +3261,9 @@ class CLIManager:
                 "Do you want to unstake from a specific [blue]ss58 address[/blue] or a registered [red]wallet hotkey"
                 "[/red]?\n"
                 "[Enter '[blue]ss58[/blue]' for an address or '[red]hotkey[/red]' for a wallet hotkey] (default is "
-                "'[blue]ss58[/blue]')",
+                "'[red]hotkey[/red]')",
                 choices=["ss58", "hotkey"],
-                default="ss58",
+                default="hotkey",
                 show_choices=False,
                 show_default=False,
             )
@@ -3631,7 +3660,7 @@ class CLIManager:
             raise typer.Exit()
 
         if not param_name:
-            hyperparam_list = list(HYPERPARAMS.keys())
+            hyperparam_list = [field.name for field in fields(SubnetHyperparameters)]
             console.print("Available hyperparameters:\n")
             for idx, param in enumerate(hyperparam_list, start=1):
                 console.print(f"  {idx}. {param}")
@@ -4024,7 +4053,7 @@ class CLIManager:
             None,
             "--salt",
             "-s",
-            help="Corresponding salt for the hash function, e.g. -s 163 -s 241 -s 217 ...",
+            help="Corresponding salt for the hash function, e.g. -s 163,241,217 ...",
         ),
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -544,10 +544,18 @@ class SubtensorInterface:
             all_netuids = netuids_with_registered_hotkeys
 
         else:
-            all_netuids = [
+            filtered_netuids = [
                 netuid for netuid in all_netuids if netuid in filter_for_netuids
             ]
-            all_netuids.extend(netuids_with_registered_hotkeys)
+
+            registered_hotkeys_filtered = [
+                netuid
+                for netuid in netuids_with_registered_hotkeys
+                if netuid in filter_for_netuids
+            ]
+
+            # Combine both filtered lists
+            all_netuids = filtered_netuids + registered_hotkeys_filtered
 
         return list(set(all_netuids))
 

--- a/bittensor_cli/src/commands/root.py
+++ b/bittensor_cli/src/commands/root.py
@@ -764,11 +764,10 @@ async def root_list(subtensor: SubtensorInterface):
             border_style="bright_black",
             leading=True,
         )
-            
 
         if not root_neurons:
             err_console.print(
-                f"[red]Error: No neurons detected on network:[/red] [white]{subtensor}"
+                f"[red]Error: No neurons detected on the network:[/red] [white]{subtensor}"
             )
             raise typer.Exit()
         
@@ -1506,10 +1505,10 @@ async def my_delegates(
                 )
     if console.width < 150:
         console.print(
-            "[yellow]Warning: Your terminal width might be too small to view all information clearly"
+            "[yellow]Warning: Your terminal width might be too small to view all the information clearly"
         )
     console.print(table)
-    console.print(f"Total delegated Tao: {total_delegated}")
+    console.print(f"Total delegated TAO: {total_delegated}")
 
 
 async def list_delegates(subtensor: SubtensorInterface):

--- a/bittensor_cli/src/commands/stake/stake.py
+++ b/bittensor_cli/src/commands/stake/stake.py
@@ -1025,14 +1025,15 @@ async def show(
             total_balance += cast(Balance, acc["balance"]).tao
             for key, value in cast(dict, acc["accounts"]).items():
                 if value["name"] and value["name"] != key:
-                    account_display_name = f"[bright_cyan]({value['name']})[/bright_cyan]   [bright_magenta]{key}[/bright_magenta]"
+                    account_display_name = f"{value['name']}"
                 else:
-                    account_display_name = f"[bright_cyan](~)[/bright_cyan]   [bright_magenta]{key}[/bright_magenta]"
+                    account_display_name = "(~)"
                 rows.append(
                     [
                         "",
                         "",
                         account_display_name,
+                        key,
                         str(value["stake"]),
                         str(value["rate"]),
                     ]
@@ -1092,7 +1093,8 @@ async def show(
                 style="dark_sea_green",
                 ratio=1,
             ),
-            Column("[bold white]Hotkey", ratio=7, no_wrap=True),
+            Column("[bold white]Account", style="bright_cyan", ratio=3),
+            Column("[bold white]Hotkey", ratio=7, no_wrap=True, style="bright_magenta"),
             Column(
                 "[bold white]Stake",
                 metadata["total_stake"],

--- a/tests/e2e_tests/test_root.py
+++ b/tests/e2e_tests/test_root.py
@@ -83,10 +83,10 @@ def test_root_commands(local_chain, wallet_setup):
     assert bob_root_info[0] == "0"
 
     # ADDRESS: Assert correct hotkey is registered
-    assert bob_root_info[3] == wallet_bob.hotkey.ss58_address
+    assert bob_root_info[4] == wallet_bob.hotkey.ss58_address
 
     # SENATOR: Since there are senator slots empty, Bob is assigned senator status
-    assert bob_root_info[7] == "Yes"
+    assert bob_root_info[8] == "Yes"
 
     # List all root delegates in the network
     check_delegates = exec_command_alice(

--- a/tests/e2e_tests/test_staking_sudo.py
+++ b/tests/e2e_tests/test_staking_sudo.py
@@ -121,7 +121,7 @@ def test_staking(local_chain, wallet_setup):
     cleaned_stake = [
         re.sub(r"\s+", " ", line) for line in show_stake.stdout.splitlines()
     ]
-    stake_added = cleaned_stake[6].split()[5].strip("τ")
+    stake_added = cleaned_stake[6].split()[6].strip("τ")
     assert Balance.from_tao(100) == Balance.from_tao(float(stake_added))
 
     # TODO: Ask nucleus the rate limit and wait epoch


### PR DESCRIPTION
- Adds `--netuid` alias to --netuids used in wallet inspect + overview
- Enhances UI of `set config` -> Now we display current configs + selection is through numbers 
- Prompts for wallet name beforehand in `create-hotkey`
- Changes default input in stake_add and stake_remove to hotkey instead of ss58
- Updates sudo_set to display 1-1 numbering w.r.t current hyperparams table
- Updates help texts
- Fixes netuid filtering in overview, inspect
- Orders root list with largest stake
- Adds back account column in stake show
- Table readability enhancements