### PR TITLE
Fix/delegate all

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -2670,7 +2670,7 @@ class CLIManager:
             root.delegate_stake(
                 wallet,
                 self.initialize_chain(network, chain),
-                float(amount),
+                amount,
                 delegate_ss58key,
                 prompt,
             )
@@ -2741,7 +2741,7 @@ class CLIManager:
             root.delegate_unstake(
                 wallet,
                 self.initialize_chain(network, chain),
-                float(amount),
+                amount,
                 delegate_ss58key,
                 prompt,
             )

--- a/bittensor_cli/src/commands/root.py
+++ b/bittensor_cli/src/commands/root.py
@@ -484,19 +484,19 @@ async def delegate_extrinsic(
              the response is `True`.
     """
 
-    async def _do_delegation(staking_balance: Balance) -> tuple[bool, str]:
+    async def _do_delegation(staking_balance_: Balance) -> tuple[bool, str]:
         """Performs the delegation extrinsic call to the chain."""
         if delegate:
             call = await subtensor.substrate.compose_call(
                 call_module="SubtensorModule",
                 call_function="add_stake",
-                call_params={"hotkey": delegate_ss58, "amount_staked": staking_balance.rao},
+                call_params={"hotkey": delegate_ss58, "amount_staked": staking_balance_.rao},
             )
         else:
             call = await subtensor.substrate.compose_call(
                 call_module="SubtensorModule",
                 call_function="remove_stake",
-                call_params={"hotkey": delegate_ss58, "amount_unstaked": staking_balance.rao},
+                call_params={"hotkey": delegate_ss58, "amount_unstaked": staking_balance_.rao},
             )
         return await subtensor.sign_and_send_extrinsic(
             call, wallet, wait_for_inclusion, wait_for_finalization

--- a/bittensor_cli/src/commands/root.py
+++ b/bittensor_cli/src/commands/root.py
@@ -567,7 +567,11 @@ async def delegate_extrinsic(
     # Convert to bittensor.Balance
     if amount is None:
         # Stake it all.
-        staking_balance = Balance.from_tao(my_prev_coldkey_balance.tao)
+        if delegate_string == "delegate":
+            staking_balance = Balance.from_tao(my_prev_coldkey_balance.tao)
+        else:
+            # Unstake all
+            staking_balance = Balance.from_tao(my_prev_delegated_stake.tao)
     else:
         staking_balance = Balance.from_tao(amount)
 


### PR DESCRIPTION
Changes made:

1. Fixed the issue when `--all` option is used for `delegate-stake` and `undelegate-stake`.
2. Existential deposit is requested from the subtensor (previously: hardcoded 1`000 rao).
3. Fixed the issue when updated staking value (existential deposit subtracted) is not used for the stake or unstake.
4. Unit tests updated to catch the previous error.