### PR TITLE
`root my-delegates` ask for path instead of name when using `--all`

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -2809,6 +2809,7 @@ class CLIManager:
             wallet_path,
             wallet_hotkey,
             ask_for=([WO.NAME] if not all_wallets else [WO.PATH]),
+            validate=WV.WALLET if not all_wallets else WV.NONE
         )
         self._run_command(
             root.my_delegates(

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -2805,7 +2805,10 @@ class CLIManager:
         """
         self.verbosity_handler(quiet, verbose)
         wallet = self.wallet_ask(
-            wallet_name, wallet_path, wallet_hotkey, ask_for=[WO.NAME]
+            wallet_name,
+            wallet_path,
+            wallet_hotkey,
+            ask_for=([WO.NAME] if not all_wallets else [WO.PATH]),
         )
         self._run_command(
             root.my_delegates(

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/opentensor/btcli",
     author="bittensor.com",
-    packages=find_packages(exclude=["tests", "tests.*", "*/tests/*", "*/tests"]) + ['bittensor_cli.src.bittensor.templates'],
+    packages=find_packages(exclude=["tests", "tests.*", "*/tests/*", "*/tests"])
+    + ["bittensor_cli.src.bittensor.templates"],
     include_package_data=True,
     package_data={
         "": ["templates/*"],

--- a/tests/e2e_tests/test_senate.py
+++ b/tests/e2e_tests/test_senate.py
@@ -88,7 +88,7 @@ def test_senate(local_chain, wallet_setup):
 
     # Assert Bob is now part of the senate
     assert wallet_bob.hotkey.ss58_address in root_senate_after_reg.stdout
-    
+
     # Manually add a proposal on the chain & assert
     success = asyncio.run(call_add_proposal(local_chain, wallet_bob))
     assert success is True
@@ -154,10 +154,10 @@ def test_senate(local_chain, wallet_setup):
     assert proposals_after_aye_output[5] == "Aye"
 
     # Aye votes increased to 1
-    assert proposals_after_aye_output[2] == '1'
+    assert proposals_after_aye_output[2] == "1"
 
     # Nay votes remain 0
-    assert proposals_after_aye_output[3] == '0'
+    assert proposals_after_aye_output[3] == "0"
 
     # Register Alice to the root network (0)
     # Registering to root automatically makes you a senator if eligible

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -11,7 +11,9 @@ from typer.testing import CliRunner
 from bittensor_wallet import Wallet
 
 if TYPE_CHECKING:
-    from bittensor_cli.src.bittensor.async_substrate_interface import AsyncSubstrateInterface
+    from bittensor_cli.src.bittensor.async_substrate_interface import (
+        AsyncSubstrateInterface,
+    )
 
 template_path = os.getcwd() + "/neurons/"
 templates_repo = "templates repository"
@@ -287,7 +289,9 @@ def uninstall_templates(install_dir):
     shutil.rmtree(install_dir)
 
 
-async def call_add_proposal(substrate: "AsyncSubstrateInterface", wallet: Wallet) -> bool:
+async def call_add_proposal(
+    substrate: "AsyncSubstrateInterface", wallet: Wallet
+) -> bool:
     async with substrate:
         proposal_call = await substrate.compose_call(
             call_module="System",
@@ -304,7 +308,9 @@ async def call_add_proposal(substrate: "AsyncSubstrateInterface", wallet: Wallet
             },
         )
 
-        extrinsic = await substrate.create_signed_extrinsic(call=call, keypair=wallet.coldkey)
+        extrinsic = await substrate.create_signed_extrinsic(
+            call=call, keypair=wallet.coldkey
+        )
         response = await substrate.submit_extrinsic(
             extrinsic,
             wait_for_inclusion=True,


### PR DESCRIPTION
Ask for wallet name for `root my-delegates` only if `--all` is not specified. If `--all` is specified, ask for the path.