### PR TITLE
Give recent commit in version

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -362,9 +362,11 @@ def version_callback(value: bool):
     """
     if value:
         try:
+            repo = Repo(os.path.dirname(os.path.dirname(__file__)))
             version = (
                 f"BTCLI version: {__version__}/"
-                f"{Repo(os.path.dirname(os.path.dirname(__file__))).active_branch.name}"
+                f"{repo.active_branch.name}/"
+                f"{repo.commit()}"
             )
         except GitError:
             version = f"BTCLI version: {__version__}"


### PR DESCRIPTION
Displays the most recent commit in the version history when used from source (in addition to the version and branch name.

`btcli --version` now gives `BTCLI version: 8.0.0/staging/5ce9bfc757398cbf3788c2870091d457ad5c7af0` instead of `BTCLI version: 8.0.0/staging`