### PR TITLE
Utils App with convert command

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -4348,20 +4348,25 @@ class CLIManager:
             None, "--tao", help="Convert amount from Tao"
         ),
     ):
+        """
+        Allows for converting between tao and rao using the specified flags
+        """
         if from_tao is None and from_rao is None:
             err_console.print("Specify `--rao` and/or `--tao`.")
             raise typer.Exit()
         if from_rao is not None:
+            rao = int(float(from_rao))
             console.print(
-                f"{from_rao}{Balance.rao_unit}",
+                f"{rao}{Balance.rao_unit}",
                 "=",
-                Balance.from_rao(int(float(from_rao))),
+                Balance.from_rao(rao),
             )
         if from_tao is not None:
+            tao = float(from_tao)
             console.print(
-                f"{Balance.unit}{from_tao}",
+                f"{Balance.unit}{tao}",
                 "=",
-                f"{Balance.from_tao(float(from_tao)).rao}{Balance.rao_unit}",
+                f"{Balance.from_tao(tao).rao}{Balance.rao_unit}",
             )
 
     def run(self):

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -26,6 +26,7 @@ from bittensor_cli.src import (
     Constants,
 )
 from bittensor_cli.src.bittensor import utils
+from bittensor_cli.src.bittensor.balances import Balance
 from bittensor_cli.src.bittensor.async_substrate_interface import (
     SubstrateRequestException,
 )
@@ -400,6 +401,7 @@ class CLIManager:
     root_app: typer.Typer
     subnets_app: typer.Typer
     weights_app: typer.Typer
+    utils_app = typer.Typer(epilog=_epilog)
 
     def __init__(self):
         self.config = {
@@ -523,6 +525,9 @@ class CLIManager:
         self.app.add_typer(
             self.weights_app, name="weight", hidden=True, no_args_is_help=True
         )
+
+        # utils app
+        self.app.add_typer(self.utils_app, name="utils", no_args_is_help=True)
 
         # config commands
         self.config_app.command("set")(self.set_config)
@@ -4332,6 +4337,32 @@ class CLIManager:
                 __version_as_int__,
             )
         )
+
+    @staticmethod
+    @utils_app.command("convert")
+    def convert(
+        from_rao: Optional[str] = typer.Option(
+            None, "--rao", help="Convert amount from Rao"
+        ),
+        from_tao: Optional[float] = typer.Option(
+            None, "--tao", help="Convert amount from Tao"
+        ),
+    ):
+        if from_tao is None and from_rao is None:
+            err_console.print("Specify `--rao` and/or `--tao`.")
+            raise typer.Exit()
+        if from_rao is not None:
+            console.print(
+                f"{from_rao}{Balance.rao_unit}",
+                "=",
+                Balance.from_rao(int(float(from_rao))),
+            )
+        if from_tao is not None:
+            console.print(
+                f"{Balance.unit}{from_tao}",
+                "=",
+                f"{Balance.from_tao(float(from_tao)).rao}{Balance.rao_unit}",
+            )
 
     def run(self):
         self.app()


### PR DESCRIPTION
Allows for rao/tao conversion. Will likely grow when alpha is introduced in rao branch.

Allows for converting like so:
`btcli utils convert --rao 100` => `100ρ = τ0.000000`
`btcli utils convert --tao 100` => `τ100.0 = 100000000000ρ`
`btcli utils convert --tao 100 --rao 100` => 
```
100ρ = τ0.000000
τ100.0 = 100000000000ρ
```

`btcli utils convert --rao 1e9` => `1000000000ρ = τ1.000000`
`btcli utils convert --rao 100_000_000` => `100000000ρ = τ0.100000`