### PR TITLE
Fixes for rpc request error handler, root list default empty values, prev delegate fetching

### DIFF
--- a/bittensor_cli/src/bittensor/async_substrate_interface.py
+++ b/bittensor_cli/src/bittensor/async_substrate_interface.py
@@ -1708,7 +1708,7 @@ class AsyncSubstrateInterface:
         result = await self._make_rpc_request(payloads, runtime=runtime)
         if "error" in result[payload_id][0]:
             raise SubstrateRequestException(
-                result["rpc_request"][0]["error"]["message"]
+                result[payload_id][0]["error"]["message"]
             )
         if "result" in result[payload_id][0]:
             return result[payload_id][0]

--- a/bittensor_cli/src/commands/root.py
+++ b/bittensor_cli/src/commands/root.py
@@ -721,7 +721,7 @@ async def root_list(subtensor: SubtensorInterface):
 
         rn: list[NeuronInfoLite] = await subtensor.neurons_lite(netuid=0)
         if not rn:
-            return None, None, None, None
+            return [], [], {}, {}
 
         di: dict[str, DelegatesDetails] = await subtensor.get_delegate_identities()
         ts: dict[str, ScaleType] = await subtensor.substrate.query_multiple(


### PR DESCRIPTION
In #131 we changed the request id of "rpc_request" to a randomised ID. Unfortunately, I neglected to update the error handler to reflect this change.

`root list` would fail because of None values in an ugly way. Use default empty values (such as `[]`) for returns now.

Fixes `root list-delegates` running on non-archive nodes (such as local chain) by attempting to grab at a -1200 block offset first, then -200, then defaulting to None if previous delegates cannot be fetched.