### PR TITLE
Remove old commit reveal hyperparameter and add a new one.

### DIFF
--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -334,7 +334,7 @@ HYPERPARAMS = {
     "kappa": "sudo_set_kappa",
     "difficulty": "sudo_set_difficulty",
     "bonds_moving_avg": "sudo_set_bonds_moving_average",
-    "commit_reveal_weights_interval": "sudo_set_commit_reveal_weights_interval",
+    "commit_reveal_periods": "sudo_set_commit_reveal_weights_periods",
     "commit_reveal_weights_enabled": "sudo_set_commit_reveal_weights_enabled",
     "alpha_values": "sudo_set_alpha_values",
     "liquid_alpha_enabled": "sudo_set_liquid_alpha_enabled",

--- a/bittensor_cli/src/bittensor/chain_data.py
+++ b/bittensor_cli/src/bittensor/chain_data.py
@@ -87,7 +87,7 @@ class SubnetHyperparameters:
     max_validators: int
     adjustment_alpha: int
     difficulty: int
-    commit_reveal_weights_interval: int
+    commit_reveal_periods: int
     commit_reveal_weights_enabled: bool
     alpha_high: int
     alpha_low: int
@@ -119,7 +119,7 @@ class SubnetHyperparameters:
             max_validators=decoded.max_validators,
             adjustment_alpha=decoded.adjustment_alpha,
             difficulty=decoded.difficulty,
-            commit_reveal_weights_interval=decoded.commit_reveal_weights_interval,
+            commit_reveal_periods=decoded.commit_reveal_periods,
             commit_reveal_weights_enabled=decoded.commit_reveal_weights_enabled,
             alpha_high=decoded.alpha_high,
             alpha_low=decoded.alpha_low,
@@ -721,7 +721,7 @@ custom_rpc_type_registry = {
                 ["max_validators", "Compact<u16>"],
                 ["adjustment_alpha", "Compact<u64>"],
                 ["difficulty", "Compact<u64>"],
-                ["commit_reveal_weights_interval", "Compact<u64>"],
+                ["commit_reveal_periods", "Compact<u64>"],
                 ["commit_reveal_weights_enabled", "bool"],
                 ["alpha_high", "Compact<u16>"],
                 ["alpha_low", "Compact<u16>"],

--- a/bittensor_cli/src/commands/weights.py
+++ b/bittensor_cli/src/commands/weights.py
@@ -148,7 +148,7 @@ class SetWeightsExtrinsic:
     ) -> tuple[bool, str]:
         interval = int(
             await self.subtensor.get_hyperparameter(
-                param_name="get_commit_reveal_weights_interval",
+                param_name="get_commit_reveal_periods",
                 netuid=self.netuid,
                 reuse_block=False,
             )


### PR DESCRIPTION
Updated variable names and parameters from commit_reveal_weights_interval to commit_reveal_periods for consistency and clarity across multiple files. This includes changes in function parameters and dictionary keys.