### PR TITLE
fix: initalise sucess var before its used

### DIFF
--- a/bittensor_cli/src/bittensor/extrinsics/registration.py
+++ b/bittensor_cli/src/bittensor/extrinsics/registration.py
@@ -602,6 +602,8 @@ async def register_extrinsic(
                     extrinsic = await subtensor.substrate.create_signed_extrinsic(
                         call=call, keypair=wallet.hotkey
                     )
+                    success = False
+                    err_msg = ""
                     response = await subtensor.substrate.submit_extrinsic(
                         extrinsic,
                         wait_for_inclusion=wait_for_inclusion,


### PR DESCRIPTION
POW registrations fail because we dont initialise `success` before we use it.

```
                            │ │
│ │                wallet = name: 'default', hotkey: 'foo', path: '~//home/ubuntu/.bittensor/wallets/'    │ │
│ ╰───────────────────────────────────────────────────────────────────────────────────────────────────────╯ │
╰───────────────────────────────────────────────────────────────────────────────────────────────────────────╯
UnboundLocalError: local variable 'success' referenced before assignment
```