### PR TITLE
Fix cuda pow registration

### DIFF
--- a/bittensor_cli/src/bittensor/extrinsics/registration.py
+++ b/bittensor_cli/src/bittensor/extrinsics/registration.py
@@ -918,6 +918,9 @@ async def _block_solver(
     stop_event.clear()
 
     solution_queue = Queue()
+    if cuda:
+        num_processes = len(dev_id)
+
     finished_queues = [Queue() for _ in range(num_processes)]
     check_block = Lock()
 
@@ -927,7 +930,6 @@ async def _block_solver(
 
     if cuda:
         ## Create a worker per CUDA device
-        num_processes = len(dev_id)
         solvers = [
             _CUDASolver(
                 i,


### PR DESCRIPTION
In CUDA POW Registration, #210 reported that the num processes was being accessed before being set (only in CUDA use). This resolves that by setting it before accessing.