### PR TITLE
Support hotkey names for include/exclude in st add/remove

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3369,20 +3369,24 @@ class CLIManager:
             )
 
         if include_hotkeys:
-            include_hotkeys = parse_to_list(
+            included_hotkeys = parse_to_list(
                 include_hotkeys,
                 str,
-                "Hotkeys must be a comma-separated list of ss58s, e.g., `--include-hotkeys 5Grw....,5Grw....`.",
-                is_ss58=True,
+                "Hotkeys must be a comma-separated list of ss58s or hotkey names, e.g., "
+                "`--include-hotkeys 5Grw....,5Grw....`.",
             )
+        else:
+            included_hotkeys = []
 
         if exclude_hotkeys:
-            exclude_hotkeys = parse_to_list(
+            excluded_hotkeys = parse_to_list(
                 exclude_hotkeys,
                 str,
-                "Hotkeys must be a comma-separated list of ss58s, e.g., `--exclude-hotkeys 5Grw....,5Grw....`.",
-                is_ss58=True,
+                "Hotkeys must be a comma-separated list of ss58s or hotkey names, e.g., "
+                "`--exclude-hotkeys 5Grw....,5Grw....`.",
             )
+        else:
+            excluded_hotkeys = []
 
         return self._run_command(
             stake.stake_add(
@@ -3391,8 +3395,8 @@ class CLIManager:
                 amount,
                 stake_all,
                 max_stake,
-                include_hotkeys,
-                exclude_hotkeys,
+                included_hotkeys,
+                excluded_hotkeys,
                 all_hotkeys,
                 prompt,
                 hotkey_ss58_address,
@@ -3524,20 +3528,24 @@ class CLIManager:
             )
 
         if include_hotkeys:
-            include_hotkeys = parse_to_list(
+            included_hotkeys = parse_to_list(
                 include_hotkeys,
                 str,
-                "Hotkeys must be a comma-separated list of ss58s, e.g., `--include-hotkeys 5Grw....,5Grw....`.",
-                is_ss58=True,
+                "Hotkeys must be a comma-separated list of ss58s or hotkey names, e.g., "
+                "`--include-hotkeys 5Grw....,5Grw....`.",
             )
+        else:
+            included_hotkeys = []
 
         if exclude_hotkeys:
-            exclude_hotkeys = parse_to_list(
+            excluded_hotkeys = parse_to_list(
                 exclude_hotkeys,
                 str,
-                "Hotkeys must be a comma-separated list of ss58s, e.g., `--exclude-hotkeys 5Grw....,5Grw....`.",
-                is_ss58=True,
+                "Hotkeys must be a comma-separated list of ss58s or hotkey names, e.g., "
+                "`--exclude-hotkeys 5Grw....,5Grw....`.",
             )
+        else:
+            excluded_hotkeys = []
 
         return self._run_command(
             stake.unstake(
@@ -3545,8 +3553,8 @@ class CLIManager:
                 self.initialize_chain(network),
                 hotkey_ss58_address,
                 all_hotkeys,
-                include_hotkeys,
-                exclude_hotkeys,
+                included_hotkeys,
+                excluded_hotkeys,
                 amount,
                 keep_stake,
                 unstake_all,

--- a/bittensor_cli/src/commands/stake/stake.py
+++ b/bittensor_cli/src/commands/stake/stake.py
@@ -1182,6 +1182,7 @@ async def stake_add(
             (wallet.hotkey_str, wallet.hotkey.ss58_address)
             for wallet in all_hotkeys_
             if wallet.hotkey_str not in exclude_hotkeys
+            and wallet.hotkey.ss58_address not in exclude_hotkeys
         ]  # definitely wallets
 
     elif include_hotkeys:
@@ -1349,6 +1350,7 @@ async def unstake(
             (wallet.hotkey_str, wallet.hotkey.ss58_address)
             for wallet in all_hotkeys_
             if wallet.hotkey_str not in exclude_hotkeys
+            and wallet.hotkey.ss58_address not in hotkeys_to_unstake_from
         ]  # definitely wallets
 
     elif include_hotkeys:

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -723,7 +723,11 @@ async def overview(
                 de_registered_neurons.append(de_registered_neuron)
 
                 # Add this hotkey to the wallets dict
-                wallet_ = WalletLike(name=wallet.name, hotkey_ss58=hotkey_addr, hotkey_str=hotkey_addr[:5])
+                wallet_ = WalletLike(
+                    name=wallet.name,
+                    hotkey_ss58=hotkey_addr,
+                    hotkey_str=hotkey_addr[:5],
+                )
                 # Indicates a hotkey not on local machine but exists in stake_info obj on-chain
                 if hotkey_coldkey_to_hotkey_wallet.get(hotkey_addr) is None:
                     hotkey_coldkey_to_hotkey_wallet[hotkey_addr] = {}


### PR DESCRIPTION
Allows for using hotkey names or ss58 addresses in include/exclude options for stake add and stake remove.

Resolves #191 