### PR TITLE
fix: update Taostats domain and use new transfer API

### DIFF
--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -310,9 +310,9 @@ NETWORK_EXPLORER_MAP = {
         "finney": "https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fentrypoint-finney.opentensor.ai%3A443#/explorer",
     },
     "taostats": {
-        "local": "https://x.taostats.io",
-        "endpoint": "https://x.taostats.io",
-        "finney": "https://x.taostats.io",
+        "local": "https://taostats.io",
+        "endpoint": "https://taostats.io",
+        "finney": "https://taostats.io",
     },
 }
 


### PR DESCRIPTION
The Subquery graph was disabled a few weeks ago, we also removed the `x` subdomain. This PR should migrate you to the new API endpoint as well as the new website domain.

The limit has been changed from 1000 to 200 as 200 is our default limit now, I included it in the params just to make it obvious how many results to expect.

This is my first dabble with Python... please be cautious merging this...