### PR TITLE
websockets version bump

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ rich~=13.7
 scalecodec==1.2.11
 substrate-interface~=1.7.9
 typer~=0.12
-websockets>=12.0
+websockets>=13.0
 bittensor-wallet>=2.0.2
 bt-decode==0.2.0a0


### PR DESCRIPTION
With websockets<13, people were experiencing failures caused by a `read_limit` kwarg, which doesn't exist in websockets<13.

```
/Users/<me>/btcli_venv/lib/python3.12/site-packages/websockets/asyncio/client.py", line 367, in create_connection
    _, connection = await loop.create_connection(factory, **kwargs)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: BaseEventLoop.create_connection() got an unexpected keyword argument 'read_limit'
```