### PR TITLE
Show hyperparams during `sudo set` only sometimes

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3884,7 +3884,7 @@ class CLIManager:
         """
         self.verbosity_handler(quiet, verbose)
 
-        if not param_name and not param_value:
+        if not param_name or not param_value:
             hyperparams = self._run_command(
                 sudo.get_hyperparameters(self.initialize_chain(network), netuid)
             )

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3884,12 +3884,12 @@ class CLIManager:
         """
         self.verbosity_handler(quiet, verbose)
 
-        hyperparams = self._run_command(
-            sudo.get_hyperparameters(self.initialize_chain(network), netuid)
-        )
-
-        if not hyperparams:
-            raise typer.Exit()
+        if not param_name and not param_value:
+            hyperparams = self._run_command(
+                sudo.get_hyperparameters(self.initialize_chain(network), netuid)
+            )
+            if not hyperparams:
+                raise typer.Exit()
 
         if not param_name:
             hyperparam_list = [field.name for field in fields(SubnetHyperparameters)]

--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -340,7 +340,10 @@ HYPERPARAMS = {
     "max_validators": ("sudo_set_max_allowed_validators", True),
     "adjustment_alpha": ("sudo_set_adjustment_alpha", False),
     "difficulty": ("sudo_set_difficulty", False),
-    "commit_reveal_weights_interval": ("sudo_set_commit_reveal_weights_interval", False),
+    "commit_reveal_weights_interval": (
+        "sudo_set_commit_reveal_weights_interval",
+        False,
+    ),
     "commit_reveal_weights_enabled": ("sudo_set_commit_reveal_weights_enabled", False),
     "alpha_values": ("sudo_set_alpha_values", False),
     "liquid_alpha_enabled": ("sudo_set_liquid_alpha_enabled", False),


### PR DESCRIPTION
Only show hyperparams during `btcli sudo set` when the param and value are not included.

E.g.

- `btcli sudo set --param tempo --value 10` will *not* show hyperparams
- `btcli sudo set --param tempo` will show hyperparams
- `btcli sudo set --valie 10` will show hyperparams
- `btcli sudo set` will show hyperparams
