### PR TITLE
Release/8.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 8.4.2 /2024-12-12
+
+## What's Changed
+* Removes the `.value` checks as we no longer use SCALE objects. by @thewhaleking in https://github.com/opentensor/btcli/pull/270
+* Backmerge main to staging 842 by @ibraheem-opentensor in https://github.com/opentensor/btcli/pull/273
+
+**Full Changelog**: https://github.com/opentensor/btcli/compare/v8.4.1...v8.4.2
+
 ## 8.4.1 /2024-12-05
 
 ## What's Changed

--- a/bittensor_cli/__init__.py
+++ b/bittensor_cli/__init__.py
@@ -18,6 +18,6 @@
 from .cli import CLIManager
 
 
-__version__ = "8.4.1"
+__version__ = "8.4.2"
 
 __all__ = ["CLIManager", "__version__"]

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -58,7 +58,7 @@ except ImportError:
         pass
 
 
-__version__ = "8.4.1"
+__version__ = "8.4.2"
 
 
 _core_version = re.match(r"^\d+\.\d+\.\d+", __version__).group(0)


### PR DESCRIPTION
## 8.4.2 /2024-12-12

## What's Changed
* Removes the `.value` checks as we no longer use SCALE objects. by @thewhaleking in https://github.com/opentensor/btcli/pull/270
* Backmerge main to staging 842 by @ibraheem-opentensor in https://github.com/opentensor/btcli/pull/273

**Full Changelog**: https://github.com/opentensor/btcli/compare/v8.4.1...v8.4.2