### PR TITLE
Show encrypted hotkeys in w list

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1252,7 +1252,7 @@ class CLIManager:
         """
         Displays all the wallets and their corresponding hotkeys that are located in the wallet path specified in the config.
 
-        The output display shows each wallet and its associated `ss58` addresses for the coldkey public key and any hotkeys. The output is presented in a hierarchical tree format, with each wallet as a root node and any associated hotkeys as child nodes. The `ss58` address is displayed for each coldkey and hotkey that is not encrypted and exists on the device.
+        The output display shows each wallet and its associated `ss58` addresses for the coldkey public key and any hotkeys. The output display shows each wallet and its associated `ss58` addresses for the coldkey public key and any hotkeys. The output is presented in a hierarchical tree format, with each wallet as a root node and any associated hotkeys as child nodes. The `ss58` address (or an `<ENCRYPTED>` marker, for encrypted hotkeys) is displayed for each coldkey and hotkey that exists on the device.
 
         Upon invocation, the command scans the wallet directory and prints a list of all the wallets, indicating whether the
         public keys are available (`?` denotes unavailable or encrypted keys).

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -235,7 +235,7 @@ def get_hotkey_wallets_for_wallet(
         hotkey_for_name = Wallet(path=str(wallet_path), name=wallet.name, hotkey=h_name)
         try:
             if (
-                exists := hotkey_for_name.hotkey_file.exists_on_device()
+                (exists := hotkey_for_name.hotkey_file.exists_on_device())
                 and not hotkey_for_name.hotkey_file.is_encrypted()
                 # and hotkey_for_name.coldkeypub.ss58_address
                 and hotkey_for_name.hotkey.ss58_address

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -52,14 +52,8 @@ from bittensor_cli.src.bittensor.utils import (
     retry_prompt,
     unlock_key,
     hex_to_bytes,
+    WalletLike,
 )
-
-
-class WalletLike:
-    def __init__(self, name=None, hotkey_ss58=None, hotkey_str=None):
-        self.name = name
-        self.hotkey_ss58 = hotkey_ss58
-        self.hotkey_str = hotkey_str
 
 
 async def regen_coldkey(
@@ -497,7 +491,9 @@ async def wallet_list(wallet_path: str):
         wallet_tree = root.add(
             f"[bold blue]Coldkey[/bold blue] [green]{wallet.name}[/green]  ss58_address [green]{coldkeypub_str}[/green]"
         )
-        hotkeys = utils.get_hotkey_wallets_for_wallet(wallet, show_nulls=True)
+        hotkeys = utils.get_hotkey_wallets_for_wallet(
+            wallet, show_nulls=True, show_encrypted=True
+        )
         for hkey in hotkeys:
             data = f"[bold red]Hotkey[/bold red][green] {hkey}[/green] (?)"
             if hkey:

--- a/tests/e2e_tests/test_wallet_creations.py
+++ b/tests/e2e_tests/test_wallet_creations.py
@@ -373,7 +373,7 @@ def test_wallet_regen(wallet_setup, capfd):
             "--mnemonic",
             mnemonics["coldkey"],
             "--no-use-password",
-            "--overwrite"
+            "--overwrite",
         ],
     )
 
@@ -413,7 +413,7 @@ def test_wallet_regen(wallet_setup, capfd):
             wallet_path,
             "--ss58-address",
             ss58_address,
-            "--overwrite"
+            "--overwrite",
         ],
     )
 


### PR DESCRIPTION
Allow display of basic information about encrypted hotkeys in wallets in `btcli w list`