### PR TITLE
Edge case alpha formatting

### DIFF
--- a/bittensor_cli/src/bittensor/balances.py
+++ b/bittensor_cli/src/bittensor/balances.py
@@ -76,7 +76,7 @@ class Balance:
         if self.unit == UNITS[0]:
             return f"{self.unit} {float(self.tao):,.4f}"
         else:
-            return f"{float(self.tao):,.4f} {self.unit}\u200e"
+            return f"\u200e{float(self.tao):,.4f} {self.unit}\u200e"
 
     def __rich__(self):
         return "[green]{}[/green][green]{}[/green][green].[/green][dim green]{}[/dim green]".format(


### PR DESCRIPTION
There are certain displays which require the left-to-right unicode embedding to be set at both sides of the string. I don't know why. This ensures consistency across all displays. See also: https://github.com/opentensor/bittensor/pull/2672