### PR TITLE
Arbitrary Hyperparams Setting

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3229,10 +3229,11 @@ class CLIManager:
                     ask_for=[WO.NAME, WO.PATH],
                 )
             else:
-                if not hotkey_ss58_address and not wallet_hotkey: 
+                if not hotkey_ss58_address and not wallet_hotkey:
                     hotkey_or_ss58 = Prompt.ask(
                         "Enter the [blue]hotkey[/blue] name or [blue]ss58 address[/blue] to unstake all from [dim](or enter 'all' to unstake from all hotkeys)[/dim]",
-                        default=self.config.get("wallet_hotkey") or defaults.wallet.hotkey,
+                        default=self.config.get("wallet_hotkey")
+                        or defaults.wallet.hotkey,
                     )
                 else:
                     hotkey_or_ss58 = hotkey_ss58_address or wallet_hotkey

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -26,6 +26,7 @@ from bittensor_cli.src import (
     WalletValidationTypes as WV,
     Constants,
     COLOR_PALETTE,
+    HYPERPARAMS,
 )
 from bittensor_cli.src.bittensor import utils
 from bittensor_cli.src.bittensor.balances import Balance
@@ -3984,7 +3985,7 @@ class CLIManager:
         param_name: str = typer.Option(
             "", "--param", "--parameter", help="The subnet hyperparameter to set"
         ),
-        param_value: str = typer.Option(
+        param_value: Optional[str] = typer.Option(
             "", "--value", help="Value to set the hyperparameter to."
         ),
         quiet: bool = Options.quiet,
@@ -4033,9 +4034,12 @@ class CLIManager:
             param_value = f"{low_val},{high_val}"
 
         if not param_value:
-            param_value = Prompt.ask(
-                f"Enter the new value for [{COLOR_PALETTE['GENERAL']['SUBHEADING']}]{param_name}[/{COLOR_PALETTE['GENERAL']['SUBHEADING']}] in the VALUE column format"
-            )
+            if HYPERPARAMS.get(param_name):
+                param_value = Prompt.ask(
+                    f"Enter the new value for [{COLOR_PALETTE['GENERAL']['SUBHEADING']}]{param_name}[/{COLOR_PALETTE['GENERAL']['SUBHEADING']}] in the VALUE column format"
+                )
+            else:
+                param_value = None
 
         wallet = self.wallet_ask(
             wallet_name, wallet_path, wallet_hotkey, ask_for=[WO.NAME, WO.PATH]

--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -672,7 +672,7 @@ HYPERPARAMS = {
     "commit_reveal_weights_enabled": ("sudo_set_commit_reveal_weights_enabled", False),
     "alpha_values": ("sudo_set_alpha_values", False),
     "liquid_alpha_enabled": ("sudo_set_liquid_alpha_enabled", False),
-    "network_registration_allowed": ("sudo_set_network_registration_allowed", False),
+    "registration_allowed": ("sudo_set_network_registration_allowed", False),
     "network_pow_registration_allowed": (
         "sudo_set_network_pow_registration_allowed",
         False,

--- a/bittensor_cli/src/commands/stake/add.py
+++ b/bittensor_cli/src/commands/stake/add.py
@@ -107,9 +107,7 @@ async def stake_add(
                 )
                 return
             else:
-                err_out(
-                    f"\n{failure_prelude} with error: {format_error_message(e)}"
-                )
+                err_out(f"\n{failure_prelude} with error: {format_error_message(e)}")
             return
         else:
             await response.process_events()
@@ -180,9 +178,7 @@ async def stake_add(
                 extrinsic, wait_for_inclusion=True, wait_for_finalization=False
             )
         except SubstrateRequestException as e:
-            err_out(
-                f"\n{failure_prelude} with error: {format_error_message(e)}"
-            )
+            err_out(f"\n{failure_prelude} with error: {format_error_message(e)}")
             return
         else:
             await response.process_events()

--- a/bittensor_cli/src/commands/stake/remove.py
+++ b/bittensor_cli/src/commands/stake/remove.py
@@ -666,9 +666,7 @@ async def _safe_unstake_extrinsic(
             )
             return
         else:
-            err_out(
-                f"\n{failure_prelude} with error: {format_error_message(e)}"
-            )
+            err_out(f"\n{failure_prelude} with error: {format_error_message(e)}")
         return
 
     await response.process_events()

--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -889,8 +889,8 @@ async def show(
             total_emission_per_block = 0
             for netuid_ in range(len(all_subnets)):
                 subnet = all_subnets[netuid_]
-                emission_on_subnet = (
-                    root_state.emission_history[netuid_][idx] / (subnet.tempo or 1)
+                emission_on_subnet = root_state.emission_history[netuid_][idx] / (
+                    subnet.tempo or 1
                 )
                 total_emission_per_block += subnet.alpha_to_tao(
                     Balance.from_rao(emission_on_subnet)

--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -889,8 +889,8 @@ async def show(
             total_emission_per_block = 0
             for netuid_ in range(len(all_subnets)):
                 subnet = all_subnets[netuid_]
-                emission_on_subnet = (
-                    root_state.emission_history[netuid_][idx] / subnet.tempo
+                emission_on_subnet = root_state.emission_history[netuid_][idx] / (
+                    subnet.tempo or 1
                 )
                 total_emission_per_block += subnet.alpha_to_tao(
                     Balance.from_rao(emission_on_subnet)
@@ -2135,9 +2135,7 @@ async def get_identity(subtensor: "SubtensorInterface", netuid: int, title: str 
         title = "Subnet Identity"
 
     if not await subtensor.subnet_exists(netuid):
-        print_error(
-            f"Subnet {netuid} does not exist."
-        )
+        print_error(f"Subnet {netuid} does not exist.")
         raise typer.Exit()
 
     with console.status(

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -135,7 +135,7 @@ async def set_hyperparameter_extrinsic(
     wallet: "Wallet",
     netuid: int,
     parameter: str,
-    value: Union[str, bool, float, list[float]],
+    value: Optional[Union[str, bool, float, list[float]]],
     wait_for_inclusion: bool = False,
     wait_for_finalization: bool = True,
 ) -> bool:
@@ -549,7 +549,7 @@ async def sudo_set_hyperparameter(
     subtensor: "SubtensorInterface",
     netuid: int,
     param_name: str,
-    param_value: str,
+    param_value: Optional[str],
 ):
     """Set subnet hyperparameters."""
 

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -184,11 +184,15 @@ async def set_hyperparameter_extrinsic(
             )
             return False
 
+    substrate = subtensor.substrate
+    msg_value = value if not arbitrary_extrinsic else call_params
     with console.status(
-        f":satellite: Setting hyperparameter [{COLOR_PALETTE['GENERAL']['SUBHEADING']}]{parameter}[/{COLOR_PALETTE['GENERAL']['SUBHEADING']}] to [{COLOR_PALETTE['GENERAL']['SUBHEADING']}]{value}[/{COLOR_PALETTE['GENERAL']['SUBHEADING']}] on subnet: [{COLOR_PALETTE['GENERAL']['SUBHEADING']}]{netuid}[/{COLOR_PALETTE['GENERAL']['SUBHEADING']}] ...",
+        f":satellite: Setting hyperparameter [{COLOR_PALETTE['GENERAL']['SUBHEADING']}]{parameter}"
+        f"[/{COLOR_PALETTE['GENERAL']['SUBHEADING']}] to [{COLOR_PALETTE['GENERAL']['SUBHEADING']}]{msg_value}"
+        f"[/{COLOR_PALETTE['GENERAL']['SUBHEADING']}] on subnet: [{COLOR_PALETTE['GENERAL']['SUBHEADING']}]"
+        f"{netuid}[/{COLOR_PALETTE['GENERAL']['SUBHEADING']}] ...",
         spinner="earth",
     ):
-        substrate = subtensor.substrate
         if not arbitrary_extrinsic:
             extrinsic_params = await substrate.get_metadata_call_function(
                 "AdminUtils", extrinsic

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -100,7 +100,7 @@ def search_metadata(
         try:
             if val is None:
                 val = input(
-                    f"Enter a value for field '{arg_name}' with type '{arg_type_output[type_]}'"
+                    f"Enter a value for field '{arg_name}' with type '{arg_type_output[type_]}': "
                 )
             return arg_types[type_](val)
         except ValueError:

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -90,6 +90,12 @@ def search_metadata(
 
     """
 
+    def string_to_bool(val) -> bool:
+        try:
+            return {"true": True, "1": True, "0": False, "false": False}[val.lower()]
+        except KeyError:
+            return ValueError
+
     def type_converter_with_retry(type_, val, arg_name):
         try:
             if val is None:
@@ -100,8 +106,8 @@ def search_metadata(
         except ValueError:
             return type_converter_with_retry(type_, None, arg_name)
 
-    arg_types = {"bool": bool, "u16": float_to_u16, "u64": float_to_u64}
-    arg_type_output = {"bool": bool, "u16": float, "u64": float}
+    arg_types = {"bool": string_to_bool, "u16": float_to_u16, "u64": float_to_u64}
+    arg_type_output = {"bool": "bool", "u16": "float", "u64": "float"}
 
     call_crafter = {"netuid": netuid}
 


### PR DESCRIPTION
Allows setting hyperparams arbitrarily, as long as they exist in the AdminUtils pallet.

TODO: The logic for the sudo set function should be compressed beyond this.

Also changes `network_registration_allowed` to `registration_allowed` in the predefined hyperparams, as to keep in line with the `SubnetHyperparameters` class and its output.