### PR TITLE
Fix stake child get

### DIFF
--- a/bittensor_cli/src/commands/stake/children_hotkeys.py
+++ b/bittensor_cli/src/commands/stake/children_hotkeys.py
@@ -256,7 +256,7 @@ async def get_childkey_take(subtensor, hotkey: str, netuid: int) -> Optional[int
             params=[hotkey, netuid],
         )
         if childkey_take_:
-            return int(childkey_take_.value)
+            return int(childkey_take_)
 
     except SubstrateRequestException as e:
         err_console.print(f"Error querying ChildKeys: {format_error_message(e)}")


### PR DESCRIPTION
We switched to `subtensor.query` which already decodes the value.

https://discord.com/channels/1120750674595024897/1242999357436071956/1339954750552145931