### PR TITLE
fix the `--all-hotkeys` option does not work for `btcli stake remove`

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3078,6 +3078,7 @@ class CLIManager:
         ),
         all_hotkeys: bool = typer.Option(
             False,
+            "--all-hotkeys",
             help="When set, this command unstakes from all the hotkeys associated with the wallet. Do not use if specifying "
             "hotkeys in `--include-hotkeys`.",
         ),


### PR DESCRIPTION
adding the missing `param_decls` for the param `all_hotkeys` of CLIManager.stake_remove`