### PR TITLE
fix: remove double conversion in stake swap functionality [--swap_all]

### DIFF
--- a/bittensor_cli/src/commands/stake/move.py
+++ b/bittensor_cli/src/commands/stake/move.py
@@ -905,7 +905,7 @@ async def swap_stake(
         )
 
     if swap_all:
-        amount_to_swap = Balance.from_tao(current_stake).set_unit(origin_netuid)
+        amount_to_swap = current_stake.set_unit(origin_netuid)
     else:
         amount_to_swap = Balance.from_tao(amount).set_unit(origin_netuid)
 


### PR DESCRIPTION
# Fix Double Conversion Bug in Stake Swap Functionality

## Issue Description
A bug was discovered in the stake swap functionality when using the `--swap-all` flag. The bug caused massive stake amount inflation due to an unnecessary double conversion of the Balance object.

### Problem Details
- When using `--swap-all`, the code was incorrectly converting an already-converted Balance object
- This resulted in massive stake amount inflation
- Example:
  - Input stake amount: 21.5369 פ
  - Incorrectly inflated amount: 21,536,911,597.0000 פ

### Root Cause
The bug occurred in `move.py` where:
```python
# Buggy code
if swap_all:
    amount_to_swap = Balance.from_tao(current_stake).set_unit(origin_netuid)
```
The `current_stake` was already a Balance object, but `Balance.from_tao()` was being called on it again, causing double conversion.

![before](https://github.com/user-attachments/assets/8ea04298-82af-4cb1-9435-3667fb00b83f)


## Solution
Fixed by removing the unnecessary `Balance.from_tao()` conversion:
```python
# Fixed code
if swap_all:
    amount_to_swap = current_stake.set_unit(origin_netuid)
```
This change ensures the Balance object is only converted once, maintaining the correct stake amount.

![after](https://github.com/user-attachments/assets/816be95c-4da3-4537-9220-5c57185dd3b6)


## Testing Performed
- Tested with real wallet and subnet data
- Verified correct stake conversion amounts
- Tested cross-subnet stake swap functionality
- Confirmed no multiplication of amounts occurs
- Example test case:
  - Wallet: coldkey_1
  - Hotkey: hot_25
  - Origin Subnet: 45 (21.5369 פ)
  - Destination Subnet: 0
  - Result: Correct conversion to 0.7464 τ

## Impact
This fix prevents potential significant financial losses that could occur due to incorrect stake amount calculations when using the `--swap-all` flag.
