### PR TITLE
st transfer allow hotkey ss58

### DIFF
--- a/bittensor_cli/src/commands/stake/move.py
+++ b/bittensor_cli/src/commands/stake/move.py
@@ -697,6 +697,7 @@ async def transfer_stake(
     wallet: Wallet,
     subtensor: "SubtensorInterface",
     amount: float,
+    origin_hotkey: str,
     origin_netuid: int,
     dest_netuid: int,
     dest_coldkey_ss58: str,
@@ -709,6 +710,7 @@ async def transfer_stake(
         wallet (Wallet): Bittensor wallet object.
         subtensor (SubtensorInterface): Subtensor interface instance.
         amount (float): Amount to transfer.
+        origin_hotkey (str): The hotkey SS58 to transfer the stake from.
         origin_netuid (int): The netuid to transfer stake from.
         dest_netuid (int): The netuid to transfer stake to.
         dest_coldkey_ss58 (str): The destination coldkey to transfer stake to.
@@ -739,16 +741,15 @@ async def transfer_stake(
         return False
 
     # Get current stake balances
-    hotkey_ss58 = wallet.hotkey.ss58_address
     with console.status(f"Retrieving stake data from {subtensor.network}..."):
         current_stake = await subtensor.get_stake(
             coldkey_ss58=wallet.coldkeypub.ss58_address,
-            hotkey_ss58=hotkey_ss58,
+            hotkey_ss58=origin_hotkey,
             netuid=origin_netuid,
         )
         current_dest_stake = await subtensor.get_stake(
             coldkey_ss58=dest_coldkey_ss58,
-            hotkey_ss58=hotkey_ss58,
+            hotkey_ss58=origin_hotkey,
             netuid=dest_netuid,
         )
     amount_to_transfer = Balance.from_tao(amount).set_unit(origin_netuid)
@@ -768,8 +769,8 @@ async def transfer_stake(
             subtensor=subtensor,
             origin_netuid=origin_netuid,
             destination_netuid=dest_netuid,
-            origin_hotkey=hotkey_ss58,
-            destination_hotkey=hotkey_ss58,
+            origin_hotkey=origin_hotkey,
+            destination_hotkey=origin_hotkey,
             amount_to_move=amount_to_transfer,
         )
 
@@ -789,7 +790,7 @@ async def transfer_stake(
             call_function="transfer_stake",
             call_params={
                 "destination_coldkey": dest_coldkey_ss58,
-                "hotkey": hotkey_ss58,
+                "hotkey": origin_hotkey,
                 "origin_netuid": origin_netuid,
                 "destination_netuid": dest_netuid,
                 "alpha_amount": amount_to_transfer.rao,
@@ -820,12 +821,12 @@ async def transfer_stake(
     new_stake, new_dest_stake = await asyncio.gather(
         subtensor.get_stake(
             coldkey_ss58=wallet.coldkeypub.ss58_address,
-            hotkey_ss58=hotkey_ss58,
+            hotkey_ss58=origin_hotkey,
             netuid=origin_netuid,
         ),
         subtensor.get_stake(
             coldkey_ss58=dest_coldkey_ss58,
-            hotkey_ss58=hotkey_ss58,
+            hotkey_ss58=origin_hotkey,
             netuid=dest_netuid,
         ),
     )


### PR DESCRIPTION
Allows users to supply a hotkey SS58 for the origin hotkey rather than requiring the name of the hotkey in their wallet.