### PR TITLE
Git not required

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -479,7 +479,7 @@ def version_callback(value: bool):
                 f"{repo.active_branch.name}/"
                 f"{repo.commit()}"
             )
-        except (NameError, GitError):
+        except (TypeError, GitError):
             version = f"BTCLI version: {__version__}"
         typer.echo(version)
         raise typer.Exit()


### PR DESCRIPTION
Fixes #334 

We had originally dealt with this a while ago, but I accidentally added `Repo = None` when there's an import error, thus avoiding the NameError later and changing it to a TypeError. This resolves that.