### PR TITLE
Removes `typer.Exit` exceptions in commands

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -2937,7 +2937,7 @@ class CLIManager:
                     ),
                     exit_early=False,
                 )
-                if selected_hotkey is None:
+                if not selected_hotkey:
                     print_error("No delegate selected. Exiting.")
                     raise typer.Exit()
                 include_hotkeys = selected_hotkey

--- a/bittensor_cli/src/commands/stake/add.py
+++ b/bittensor_cli/src/commands/stake/add.py
@@ -1,7 +1,6 @@
 import asyncio
 from functools import partial
 
-import typer
 from typing import TYPE_CHECKING, Optional
 from rich.table import Table
 from rich.prompt import Confirm, Prompt
@@ -20,7 +19,6 @@ from bittensor_cli.src.bittensor.utils import (
     unlock_key,
 )
 from bittensor_wallet import Wallet
-from bittensor_wallet.errors import KeyFileError
 
 if TYPE_CHECKING:
     from bittensor_cli.src.bittensor.subtensor_interface import SubtensorInterface
@@ -338,7 +336,7 @@ async def stake_add(
 
     if prompt:
         if not Confirm.ask("Would you like to continue?"):
-            raise typer.Exit()
+            return False
     if not unlock_key(wallet).success:
         return False
 

--- a/bittensor_cli/src/commands/stake/list.py
+++ b/bittensor_cli/src/commands/stake/list.py
@@ -1,7 +1,6 @@
 import asyncio
 
 from typing import TYPE_CHECKING, Optional
-import typer
 
 from bittensor_wallet import Wallet
 from rich.prompt import Prompt
@@ -428,7 +427,7 @@ async def stake_list(
 
     if not hotkeys_to_substakes:
         print_error(f"No stakes found for coldkey ss58: ({coldkey_address})")
-        raise typer.Exit()
+        return
 
     if live:
         # Select one hotkey for live monitoring

--- a/bittensor_cli/src/commands/stake/move.py
+++ b/bittensor_cli/src/commands/stake/move.py
@@ -1,10 +1,8 @@
 import asyncio
 
 from typing import TYPE_CHECKING
-import typer
 
 from bittensor_wallet import Wallet
-from bittensor_wallet.errors import KeyFileError
 from rich.table import Table
 from rich.prompt import Confirm, Prompt
 
@@ -72,7 +70,7 @@ async def display_stake_movement_cross_subnets(
 
         if received_amount < Balance.from_tao(0):
             print_error("Not enough Alpha to pay the transaction fee.")
-            raise typer.Exit()
+            raise ValueError
 
         ideal_amount = amount_to_move * price
         total_slippage = ideal_amount - received_amount
@@ -228,7 +226,7 @@ async def stake_move_selection(
 
     if not hotkey_stakes:
         print_error("You have no stakes to move.")
-        raise typer.Exit()
+        raise ValueError
 
     # Display hotkeys with stakes
     table = Table(
@@ -457,7 +455,7 @@ async def stake_swap_selection(
 
     if not hotkey_stakes:
         print_error(f"No stakes found for hotkey: {wallet.hotkey_str}")
-        raise typer.Exit()
+        raise ValueError
 
     # Display available stakes
     table = Table(
@@ -540,7 +538,10 @@ async def move_stake(
     prompt: bool = True,
 ):
     if interactive_selection:
-        selection = await stake_move_selection(subtensor, wallet)
+        try:
+            selection = await stake_move_selection(subtensor, wallet)
+        except ValueError:
+            return False
         origin_hotkey = selection["origin_hotkey"]
         origin_netuid = selection["origin_netuid"]
         amount = selection["amount"]
@@ -571,7 +572,7 @@ async def move_stake(
             f"in Netuid: "
             f"[{COLOR_PALETTE['GENERAL']['SUBHEADING']}]{origin_netuid}[/{COLOR_PALETTE['GENERAL']['SUBHEADING']}]"
         )
-        raise typer.Exit()
+        return False
 
     console.print(
         f"\nOrigin Netuid: "
@@ -609,16 +610,19 @@ async def move_stake(
 
     # Slippage warning
     if prompt:
-        await display_stake_movement_cross_subnets(
-            subtensor=subtensor,
-            origin_netuid=origin_netuid,
-            destination_netuid=destination_netuid,
-            origin_hotkey=origin_hotkey,
-            destination_hotkey=destination_hotkey,
-            amount_to_move=amount_to_move_as_balance,
-        )
+        try:
+            await display_stake_movement_cross_subnets(
+                subtensor=subtensor,
+                origin_netuid=origin_netuid,
+                destination_netuid=destination_netuid,
+                origin_hotkey=origin_hotkey,
+                destination_hotkey=destination_hotkey,
+                amount_to_move=amount_to_move_as_balance,
+            )
+        except ValueError:
+            return False
         if not Confirm.ask("Would you like to continue?"):
-            raise typer.Exit()
+            return False
 
     # Perform moving operation.
     if not unlock_key(wallet).success:
@@ -763,17 +767,20 @@ async def transfer_stake(
 
     # Slippage warning
     if prompt:
-        await display_stake_movement_cross_subnets(
-            subtensor=subtensor,
-            origin_netuid=origin_netuid,
-            destination_netuid=dest_netuid,
-            origin_hotkey=origin_hotkey,
-            destination_hotkey=origin_hotkey,
-            amount_to_move=amount_to_transfer,
-        )
+        try:
+            await display_stake_movement_cross_subnets(
+                subtensor=subtensor,
+                origin_netuid=origin_netuid,
+                destination_netuid=dest_netuid,
+                origin_hotkey=origin_hotkey,
+                destination_hotkey=origin_hotkey,
+                amount_to_move=amount_to_transfer,
+            )
+        except ValueError:
+            return False
 
         if not Confirm.ask("Would you like to continue?"):
-            raise typer.Exit()
+            return False
 
     # Perform transfer operation
     if not unlock_key(wallet).success:
@@ -868,7 +875,10 @@ async def swap_stake(
     """
     hotkey_ss58 = wallet.hotkey.ss58_address
     if interactive_selection:
-        selection = await stake_swap_selection(subtensor, wallet)
+        try:
+            selection = await stake_swap_selection(subtensor, wallet)
+        except ValueError:
+            return False
         origin_netuid = selection["origin_netuid"]
         amount = selection["amount"]
         destination_netuid = selection["destination_netuid"]
@@ -916,17 +926,20 @@ async def swap_stake(
 
     # Slippage warning
     if prompt:
-        await display_stake_movement_cross_subnets(
-            subtensor=subtensor,
-            origin_netuid=origin_netuid,
-            destination_netuid=destination_netuid,
-            origin_hotkey=hotkey_ss58,
-            destination_hotkey=hotkey_ss58,
-            amount_to_move=amount_to_swap,
-        )
+        try:
+            await display_stake_movement_cross_subnets(
+                subtensor=subtensor,
+                origin_netuid=origin_netuid,
+                destination_netuid=destination_netuid,
+                origin_hotkey=hotkey_ss58,
+                destination_hotkey=hotkey_ss58,
+                amount_to_move=amount_to_swap,
+            )
+        except ValueError:
+            return False
 
         if not Confirm.ask("Would you like to continue?"):
-            raise typer.Exit()
+            return False
 
     # Perform swap operation
     if not unlock_key(wallet).success:

--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -2,10 +2,8 @@ import asyncio
 import json
 import sqlite3
 from typing import TYPE_CHECKING, Optional, cast
-import typer
 
 from bittensor_wallet import Wallet
-from bittensor_wallet.errors import KeyFileError
 from rich.prompt import Confirm, Prompt
 from rich.console import Group
 from rich.progress import Progress, BarColumn, TextColumn
@@ -814,7 +812,7 @@ async def show(
         root_info = next((s for s in all_subnets if s.netuid == 0), None)
         if root_info is None:
             print_error("The root subnet does not exist")
-            raise typer.Exit()
+            return False
 
         root_state, identities, old_identities = await asyncio.gather(
             subtensor.get_subnet_state(netuid=0, block_hash=block_hash),
@@ -1017,7 +1015,7 @@ async def show(
     async def show_subnet(netuid_: int):
         if not await subtensor.subnet_exists(netuid=netuid):
             err_console.print(f"[red]Subnet {netuid} does not exist[/red]")
-            raise typer.Exit()
+            return False
         block_hash = await subtensor.substrate.get_chain_head()
         (
             subnet_info,
@@ -1036,15 +1034,15 @@ async def show(
         )
         if subnet_state is None:
             print_error(f"Subnet {netuid_} does not exist")
-            raise typer.Exit()
+            return False
 
         if subnet_info is None:
             print_error(f"Subnet {netuid_} does not exist")
-            raise typer.Exit()
+            return False
 
         if len(subnet_state.hotkeys) == 0:
             print_error(f"Subnet {netuid_} is currently empty with 0 UIDs registered.")
-            raise typer.Exit()
+            return False
 
         # Define table properties
         table = Table(
@@ -1381,7 +1379,7 @@ async def create(
                     " are you sure you wish to continue?"
                 ):
                     console.print(":cross_mark: Aborted!")
-                    raise typer.Exit()
+                    return False
 
             identity = prompt_for_identity(
                 current_identity=current_identity,
@@ -2135,7 +2133,7 @@ async def get_identity(subtensor: "SubtensorInterface", netuid: int, title: str 
 
     if not await subtensor.subnet_exists(netuid):
         print_error(f"Subnet {netuid} does not exist.")
-        raise typer.Exit()
+        return None
 
     with console.status(
         ":satellite: [bold green]Querying subnet identity...", spinner="earth"

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -1,7 +1,6 @@
 import asyncio
 from typing import TYPE_CHECKING, Union, Optional
 
-import typer
 from bittensor_wallet import Wallet
 from rich import box
 from rich.table import Column, Table
@@ -593,7 +592,7 @@ async def sudo_set_hyperparameter(
     if success:
         console.print("\n")
         print_verbose("Fetching hyperparameters")
-        await get_hyperparameters(subtensor, netuid=netuid)
+        return await get_hyperparameters(subtensor, netuid=netuid)
 
 
 async def get_hyperparameters(subtensor: "SubtensorInterface", netuid: int):
@@ -606,7 +605,7 @@ async def get_hyperparameters(subtensor: "SubtensorInterface", netuid: int):
     subnet_info = await subtensor.subnet(netuid)
     if subnet_info is None:
         print_error(f"Subnet with netuid {netuid} does not exist.")
-        raise typer.Exit()
+        return False
 
     table = Table(
         Column("[white]HYPERPARAMETER", style=COLOR_PALETTE["SUDO"]["HYPERPARAMETER"]),

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -14,7 +14,6 @@ from rich.align import Align
 from rich.table import Column, Table
 from rich.tree import Tree
 from rich.padding import Padding
-import typer
 
 from bittensor_cli.src import COLOR_PALETTE
 from bittensor_cli.src.bittensor import utils
@@ -120,7 +119,7 @@ async def regen_hotkey(
     if json_path:
         if not os.path.exists(json_path) or not os.path.isfile(json_path):
             err_console.print(f"File {json_path} does not exist")
-            raise typer.Exit()
+            return False
         with open(json_path, "r") as f:
             json_str = f.read()
 

--- a/bittensor_cli/version.py
+++ b/bittensor_cli/version.py
@@ -15,5 +15,6 @@ def version_as_int(version):
     __new_signature_version__ = 360
     return __version_as_int__
 
+
 __version__ = "9.0.3"
 __version_as_int__ = version_as_int(__version__)

--- a/tests/e2e_tests/test_root.py
+++ b/tests/e2e_tests/test_root.py
@@ -16,6 +16,7 @@ Verify commands:
 * btcli root undelegate-stake
 """
 
+
 @pytest.mark.skip(reason="Root no longer applicable. We will update this.")
 def test_root_commands(local_chain, wallet_setup):
     """

--- a/tests/e2e_tests/test_wallet_interactions.py
+++ b/tests/e2e_tests/test_wallet_interactions.py
@@ -419,7 +419,7 @@ def test_wallet_identities(local_chain, wallet_setup):
             alice_identity["name"],
             "--web-url",
             alice_identity["url"],
-            "--image-url", 
+            "--image-url",
             alice_identity["image"],
             "--discord",
             alice_identity["discord"],
@@ -444,7 +444,6 @@ def test_wallet_identities(local_chain, wallet_setup):
     assert alice_identity["discord"] in set_id_output[10]
     assert alice_identity["description"] in set_id_output[11]
     assert alice_identity["additional"] in set_id_output[12]
-
 
     # TODO: Currently coldkey + hotkey are the same for test wallets.
     # Maybe we can add a new key to help in distinguishing
@@ -471,7 +470,6 @@ def test_wallet_identities(local_chain, wallet_setup):
     assert alice_identity["discord"] in get_identity_output[9]
     assert alice_identity["description"] in get_identity_output[10]
     assert alice_identity["additional"] in get_identity_output[11]
-    
 
     # Sign a message using hotkey
     sign_using_hotkey = exec_command_alice(

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -73,8 +73,7 @@ def extract_coldkey_balance(text: str, wallet_name: str, coldkey_address: str) -
               Returns a dictionary with all zeros if the wallet name or coldkey address is not found.
     """
     pattern = (
-        rf"{wallet_name}\s+{coldkey_address}\s+"
-        r"τ\s*([\d,]+\.\d+)"  # Free Balance
+        rf"{wallet_name}\s+{coldkey_address}\s+" r"τ\s*([\d,]+\.\d+)"  # Free Balance
     )
 
     match = re.search(pattern, text)
@@ -140,9 +139,7 @@ def validate_wallet_overview(
     pattern += r"[\d.]+\s+"  # VTRUST
     pattern += r"\*?\s*"  # VPERMIT (optional *)
     pattern += r"[\d]+\s+"  # UPDATED
-    pattern += (
-        r"(?!none)\w+\s+" if axon_active else r"none\s+"
-    )  # AXON
+    pattern += r"(?!none)\w+\s+" if axon_active else r"none\s+"  # AXON
     pattern += rf"{hotkey_ss58[:10]}\s*"  # HOTKEY_SS58
 
     # Search for the pattern in the wallet information


### PR DESCRIPTION
Removes all the `raise typer.Exit()` calls throughout the commands, and instead provides consistent returns or proper exception raising to be handled further down the line. This results in better outputs with `--verbose`