### PR TITLE
Disk-Cache Async-Substrate-Interface Calls

### DIFF
--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -9,7 +9,7 @@ from async_substrate_interface.errors import SubstrateRequestException
 import typer
 
 
-from async_substrate_interface.async_substrate import AsyncSubstrateInterface
+from async_substrate_interface.async_substrate import DiskCachedAsyncSubstrateInterface as AsyncSubstrateInterface
 from bittensor_cli.src.bittensor.chain_data import (
     DelegateInfo,
     StakeInfo,

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -1,4 +1,5 @@
 import asyncio
+import os
 from typing import Optional, Any, Union, TypedDict, Iterable
 
 import aiohttp
@@ -9,7 +10,10 @@ from async_substrate_interface.errors import SubstrateRequestException
 import typer
 
 
-from async_substrate_interface.async_substrate import DiskCachedAsyncSubstrateInterface as AsyncSubstrateInterface
+from async_substrate_interface.async_substrate import (
+    DiskCachedAsyncSubstrateInterface,
+    AsyncSubstrateInterface,
+)
 from bittensor_cli.src.bittensor.chain_data import (
     DelegateInfo,
     StakeInfo,
@@ -32,6 +36,12 @@ from bittensor_cli.src.bittensor.utils import (
     decode_hex_identity_dict,
     validate_chain_endpoint,
     u16_normalized_float,
+)
+
+SubstrateClass = (
+    DiskCachedAsyncSubstrateInterface
+    if os.getenv("DISK_CACHE", "0") == "1"
+    else AsyncSubstrateInterface
 )
 
 
@@ -98,7 +108,7 @@ class SubtensorInterface:
                 self.chain_endpoint = Constants.network_map[defaults.subtensor.network]
                 self.network = defaults.subtensor.network
 
-        self.substrate = AsyncSubstrateInterface(
+        self.substrate = SubstrateClass(
             url=self.chain_endpoint,
             ss58_format=SS58_FORMAT,
             type_registry=TYPE_REGISTRY,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.9,<3.13"
 dependencies = [
     "wheel",
     "async-property==0.2.2",
-    "async-substrate-interface>=1.0.6",
+    "async-substrate-interface>=1.0.7",
     "aiohttp~=3.10.2",
     "backoff~=2.2.1",
     "GitPython>=3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ requires-python = ">=3.9,<3.13"
 dependencies = [
     "wheel",
     "async-property==0.2.2",
-    "async-substrate-interface>=1.0.5",
+    "async-substrate-interface>=1.0.6",
     "aiohttp~=3.10.2",
     "backoff~=2.2.1",
     "GitPython>=3.0.0",


### PR DESCRIPTION
Uses the disk-cached async-substrate-interface. Must be used with https://github.com/opentensor/async-substrate-interface/pull/67

Considering this as an experimental feature, so requires env var of `DISK_CACHE=1` to use.