### PR TITLE
Passes prompt for pow_register

### DIFF
--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -1417,6 +1417,7 @@ async def pow_register(
     use_cuda,
     dev_id,
     threads_per_block,
+    prompt: bool
 ):
     """Register neuron."""
 
@@ -1424,7 +1425,7 @@ async def pow_register(
         subtensor,
         wallet=wallet,
         netuid=netuid,
-        prompt=True,
+        prompt=prompt,
         tpb=threads_per_block,
         update_interval=update_interval,
         num_processes=processors,


### PR DESCRIPTION
You cannot actually use `pow-register` because it attempts to pass an unknown kwarg `prompt` to `pow_register` fn.