### PR TITLE
Feat/associate hotkey

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -2274,6 +2274,7 @@ class CLIManager:
         wallet_path: Optional[str] = Options.wallet_path,
         wallet_hotkey: Optional[str] = Options.wallet_hotkey_ss58,
         network: Optional[list[str]] = Options.network,
+        prompt: bool = Options.prompt,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
     ):
@@ -2296,33 +2297,33 @@ class CLIManager:
                 default=self.config.get("wallet_name") or defaults.wallet.name,
             )
         if not wallet_hotkey:
-            hotkey_or_wallet = Prompt.ask(
+            wallet_hotkey = Prompt.ask(
                 "Enter the [blue]hotkey[/blue] name or "
                 "[blue]hotkey ss58 address[/blue] [dim](to associate with your coldkey)[/dim]"
             )
-            if is_valid_ss58_address(hotkey_or_wallet):
-                hotkey_ss58 = hotkey_or_wallet
-                wallet = self.wallet_ask(
-                    wallet_name,
-                    wallet_path,
-                    wallet_hotkey,
-                    ask_for=[WO.NAME, WO.PATH],
-                    validate=WV.WALLET,
-                )
-            else:
-                wallet = self.wallet_ask(
-                    wallet_name,
-                    wallet_path,
-                    hotkey_or_wallet,
-                    ask_for=[WO.NAME, WO.PATH, WO.HOTKEY],
-                    validate=WV.WALLET_AND_HOTKEY,
-                )
-                hotkey_ss58 = wallet.hotkey.ss58_address
+
+        if is_valid_ss58_address(wallet_hotkey):
+            hotkey_ss58 = wallet_hotkey
+            wallet = self.wallet_ask(
+                wallet_name,
+                wallet_path,
+                None,
+                ask_for=[WO.NAME, WO.PATH],
+                validate=WV.WALLET,
+            )
+        else:
+            wallet = self.wallet_ask(
+                wallet_name,
+                wallet_path,
+                wallet_hotkey,
+                ask_for=[WO.NAME, WO.PATH, WO.HOTKEY],
+                validate=WV.WALLET_AND_HOTKEY,
+            )
+            hotkey_ss58 = wallet.hotkey.ss58_address
+
         return self._run_command(
             wallets.associate_hotkey(
-                wallet,
-                self.initialize_chain(network),
-                hotkey_ss58,
+                wallet, self.initialize_chain(network), hotkey_ss58, prompt
             )
         )
 

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -2302,6 +2302,7 @@ class CLIManager:
                 "[blue]hotkey ss58 address[/blue] [dim](to associate with your coldkey)[/dim]"
             )
 
+        hotkey_display = None
         if is_valid_ss58_address(wallet_hotkey):
             hotkey_ss58 = wallet_hotkey
             wallet = self.wallet_ask(
@@ -2310,6 +2311,9 @@ class CLIManager:
                 None,
                 ask_for=[WO.NAME, WO.PATH],
                 validate=WV.WALLET,
+            )
+            hotkey_display = (
+                f"hotkey [{COLORS.GENERAL.HK}]{hotkey_ss58}[/{COLORS.GENERAL.HK}]"
             )
         else:
             wallet = self.wallet_ask(
@@ -2320,10 +2324,15 @@ class CLIManager:
                 validate=WV.WALLET_AND_HOTKEY,
             )
             hotkey_ss58 = wallet.hotkey.ss58_address
+            hotkey_display = f"hotkey [blue]{wallet_hotkey}[/blue] [{COLORS.GENERAL.HK}]({hotkey_ss58})[/{COLORS.GENERAL.HK}]"
 
         return self._run_command(
             wallets.associate_hotkey(
-                wallet, self.initialize_chain(network), hotkey_ss58, prompt
+                wallet,
+                self.initialize_chain(network),
+                hotkey_ss58,
+                hotkey_display,
+                prompt,
             )
         )
 

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -54,6 +54,7 @@ async def associate_hotkey(
     wallet: Wallet,
     subtensor: SubtensorInterface,
     hotkey_ss58: str,
+    prompt: bool = False,
 ):
     """Associates a hotkey with a wallet"""
     owner_ss58 = await subtensor.get_hotkey_owner(hotkey_ss58)
@@ -78,7 +79,9 @@ async def associate_hotkey(
             f"Hotkey [{COLORS.GENERAL.HK}]{hotkey_ss58}[/{COLORS.GENERAL.HK}] is not associated with any wallet"
         )
 
-    if not Confirm.ask("Do you want to continue with the association?"):
+    if prompt and not Confirm.ask(
+        "Do you want to continue with the association?"
+    ):
         return False
 
     if not unlock_key(wallet).success:

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -63,7 +63,7 @@ async def associate_hotkey(
     if owner_ss58:
         if owner_ss58 == wallet.coldkeypub.ss58_address:
             console.print(
-                f":white_heavy_check_mark: {hotkey_display} is already "
+                f":white_heavy_check_mark: {hotkey_display.capitalize()} is already "
                 f"associated with \nwallet [blue]{wallet.name}[/blue], "
                 f"SS58: [{COLORS.GENERAL.CK}]{owner_ss58}[/{COLORS.GENERAL.CK}]"
             )
@@ -72,12 +72,14 @@ async def associate_hotkey(
             owner_wallet = _get_wallet_by_ss58(wallet.path, owner_ss58)
             wallet_name = owner_wallet.name if owner_wallet else "unknown wallet"
             console.print(
-                f"[yellow]Warning[/yellow]: {hotkey_display} is already associated with \n"
+                f"[yellow]Warning[/yellow]: {hotkey_display.capitalize()} is already associated with \n"
                 f"wallet: [blue]{wallet_name}[/blue], SS58: [{COLORS.GENERAL.CK}]{owner_ss58}[/{COLORS.GENERAL.CK}]"
             )
             return False
     else:
-        console.print(f"{hotkey_display} is not associated with any wallet")
+        console.print(
+            f"{hotkey_display.capitalize()} is not associated with any wallet"
+        )
 
     if prompt and not Confirm.ask("Do you want to continue with the association?"):
         return False
@@ -108,7 +110,7 @@ async def associate_hotkey(
             return False
 
         console.print(
-            f"[green]:white_heavy_check_mark: Successfully associated {hotkey_display} with \n"
+            f":white_heavy_check_mark: Successfully associated {hotkey_display} with \n"
             f"wallet [blue]{wallet.name}[/blue], "
             f"SS58: [{COLORS.GENERAL.CK}]{wallet.coldkeypub.ss58_address}[/{COLORS.GENERAL.CK}]"
         )

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -50,6 +50,70 @@ from bittensor_cli.src.bittensor.utils import (
 )
 
 
+async def associate_hotkey(
+    wallet: Wallet,
+    subtensor: SubtensorInterface,
+    hotkey_ss58: str,
+):
+    """Associates a hotkey with a wallet"""
+    owner_ss58 = await subtensor.get_hotkey_owner(hotkey_ss58)
+    if owner_ss58:
+        if owner_ss58 == wallet.coldkeypub.ss58_address:
+            console.print(
+                f":white_heavy_check_mark: Hotkey [{COLORS.GENERAL.HK}]{hotkey_ss58}[/{COLORS.GENERAL.HK}] is already "
+                f"associated with \nwallet [blue]{wallet.name}[/blue], "
+                f"SS58: [{COLORS.GENERAL.CK}]{owner_ss58}[/{COLORS.GENERAL.CK}]"
+            )
+            return True
+        else:
+            owner_wallet = _get_wallet_by_ss58(wallet.path, owner_ss58)
+            wallet_name = owner_wallet.name if owner_wallet else "unknown wallet"
+            console.print(
+                f"[yellow]Warning[/yellow]: Hotkey [{COLORS.GENERAL.HK}]{hotkey_ss58}[/{COLORS.GENERAL.HK}] is already associated with \n"
+                f"wallet: [blue]{wallet_name}[/blue], SS58: [{COLORS.GENERAL.CK}]{owner_ss58}[/{COLORS.GENERAL.CK}]"
+            )
+            return False
+    else:
+        console.print(
+            f"Hotkey [{COLORS.GENERAL.HK}]{hotkey_ss58}[/{COLORS.GENERAL.HK}] is not associated with any wallet"
+        )
+
+    if not Confirm.ask("Do you want to continue with the association?"):
+        return False
+
+    if not unlock_key(wallet).success:
+        return False
+
+    call = await subtensor.substrate.compose_call(
+        call_module="SubtensorModule",
+        call_function="try_associate_hotkey",
+        call_params={
+            "hotkey": hotkey_ss58,
+        },
+    )
+
+    with console.status(":satellite: Associating hotkey on-chain..."):
+        success, err_msg = await subtensor.sign_and_send_extrinsic(
+            call,
+            wallet,
+            wait_for_inclusion=True,
+            wait_for_finalization=False,
+        )
+
+        if not success:
+            console.print(
+                f"[red]:cross_mark: Failed to associate hotkey: {err_msg}[/red]"
+            )
+            return False
+
+        console.print(
+            f"[green]:white_heavy_check_mark: Successfully associated hotkey[/green] "
+            f"[{COLORS.GENERAL.HK}]{hotkey_ss58}[/{COLORS.GENERAL.HK}] with \nwallet [blue]{wallet.name}[/blue], "
+            f"SS58: [{COLORS.GENERAL.CK}]{wallet.coldkeypub.ss58_address}[/{COLORS.GENERAL.CK}]"
+        )
+        return True
+
+
 async def regen_coldkey(
     wallet: Wallet,
     mnemonic: Optional[str],
@@ -255,6 +319,15 @@ def get_coldkey_wallets_for_path(path: str) -> list[Wallet]:
         # No wallet files found.
         wallets = []
     return wallets
+
+
+def _get_wallet_by_ss58(path: str, ss58_address: str) -> Optional[Wallet]:
+    """Find a wallet by its SS58 address in the given path."""
+    ss58_addresses, wallet_names = _get_coldkey_ss58_addresses_for_path(path)
+    for wallet_name, addr in zip(wallet_names, ss58_addresses):
+        if addr == ss58_address:
+            return Wallet(path=path, name=wallet_name)
+    return None
 
 
 def _get_coldkey_ss58_addresses_for_path(path: str) -> tuple[list[str], list[str]]:
@@ -1596,8 +1669,7 @@ async def find_coldkey_swap_extrinsic(
     """
 
     current_block, genesis_block = await asyncio.gather(
-        subtensor.substrate.get_block_number(),
-        subtensor.substrate.get_block_hash(0)
+        subtensor.substrate.get_block_number(), subtensor.substrate.get_block_hash(0)
     )
     if (
         current_block - start_block > 300

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -54,14 +54,16 @@ async def associate_hotkey(
     wallet: Wallet,
     subtensor: SubtensorInterface,
     hotkey_ss58: str,
+    hotkey_display: str,
     prompt: bool = False,
 ):
     """Associates a hotkey with a wallet"""
+
     owner_ss58 = await subtensor.get_hotkey_owner(hotkey_ss58)
     if owner_ss58:
         if owner_ss58 == wallet.coldkeypub.ss58_address:
             console.print(
-                f":white_heavy_check_mark: Hotkey [{COLORS.GENERAL.HK}]{hotkey_ss58}[/{COLORS.GENERAL.HK}] is already "
+                f":white_heavy_check_mark: {hotkey_display} is already "
                 f"associated with \nwallet [blue]{wallet.name}[/blue], "
                 f"SS58: [{COLORS.GENERAL.CK}]{owner_ss58}[/{COLORS.GENERAL.CK}]"
             )
@@ -70,18 +72,14 @@ async def associate_hotkey(
             owner_wallet = _get_wallet_by_ss58(wallet.path, owner_ss58)
             wallet_name = owner_wallet.name if owner_wallet else "unknown wallet"
             console.print(
-                f"[yellow]Warning[/yellow]: Hotkey [{COLORS.GENERAL.HK}]{hotkey_ss58}[/{COLORS.GENERAL.HK}] is already associated with \n"
+                f"[yellow]Warning[/yellow]: {hotkey_display} is already associated with \n"
                 f"wallet: [blue]{wallet_name}[/blue], SS58: [{COLORS.GENERAL.CK}]{owner_ss58}[/{COLORS.GENERAL.CK}]"
             )
             return False
     else:
-        console.print(
-            f"Hotkey [{COLORS.GENERAL.HK}]{hotkey_ss58}[/{COLORS.GENERAL.HK}] is not associated with any wallet"
-        )
+        console.print(f"{hotkey_display} is not associated with any wallet")
 
-    if prompt and not Confirm.ask(
-        "Do you want to continue with the association?"
-    ):
+    if prompt and not Confirm.ask("Do you want to continue with the association?"):
         return False
 
     if not unlock_key(wallet).success:
@@ -110,8 +108,8 @@ async def associate_hotkey(
             return False
 
         console.print(
-            f"[green]:white_heavy_check_mark: Successfully associated hotkey[/green] "
-            f"[{COLORS.GENERAL.HK}]{hotkey_ss58}[/{COLORS.GENERAL.HK}] with \nwallet [blue]{wallet.name}[/blue], "
+            f"[green]:white_heavy_check_mark: Successfully associated {hotkey_display} with \n"
+            f"wallet [blue]{wallet.name}[/blue], "
             f"SS58: [{COLORS.GENERAL.CK}]{wallet.coldkeypub.ss58_address}[/{COLORS.GENERAL.CK}]"
         )
         return True

--- a/tests/e2e_tests/test_wallet_interactions.py
+++ b/tests/e2e_tests/test_wallet_interactions.py
@@ -510,3 +510,111 @@ def test_wallet_identities(local_chain, wallet_setup):
     assert "Message signed successfully" in sign_using_coldkey.stdout
 
     print("✅ Passed wallet set-id, get-id, sign command")
+
+
+def test_wallet_associate_hotkey(local_chain, wallet_setup):
+    """
+    Test the associating hotkeys and their different cases.
+
+    Steps:
+        1. Create wallets for Alice, Bob, and Charlie
+        2. Associate a hotkey with Alice's wallet using hotkey name
+        3. Verify the association is successful
+        4. Try to associate Alice's hotkey with Bob's wallet (should fail)
+        5. Try to associate Alice's hotkey again (should show already associated)
+        6. Associate Charlie's hotkey with Bob's wallet using SS58 address
+
+    Raises:
+        AssertionError: If any of the checks or verifications fail
+    """
+    print("Testing wallet associate-hotkey command 🧪")
+
+    _, wallet_alice, wallet_path_alice, exec_command_alice = wallet_setup("//Alice")
+    _, wallet_bob, wallet_path_bob, exec_command_bob = wallet_setup("//Bob")
+    _, wallet_charlie, _, _ = wallet_setup("//Charlie")
+
+    # Associate Alice's default hotkey with her wallet
+    result = exec_command_alice(
+        command="wallet",
+        sub_command="associate-hotkey",
+        extra_args=[
+            "--wallet-path",
+            wallet_path_alice,
+            "--chain",
+            "ws://127.0.0.1:9945",
+            "--wallet-name",
+            wallet_alice.name,
+            "--wallet-hotkey",
+            wallet_alice.hotkey_str,
+            "--no-prompt",
+        ],
+    )
+
+    # Assert successful association
+    assert "Successfully associated hotkey" in result.stdout
+    assert wallet_alice.hotkey.ss58_address in result.stdout
+    assert wallet_alice.coldkeypub.ss58_address in result.stdout
+
+    # Try to associate Alice's hotkey with Bob's wallet (should fail)
+    result = exec_command_bob(
+        command="wallet",
+        sub_command="associate-hotkey",
+        extra_args=[
+            "--wallet-path",
+            wallet_path_bob,
+            "--chain",
+            "ws://127.0.0.1:9945",
+            "--wallet-name",
+            wallet_bob.name,
+            "--hotkey-ss58",
+            wallet_alice.hotkey.ss58_address,
+            "--no-prompt",
+        ],
+    )
+
+    assert "Warning" in result.stdout
+    assert "is already associated with" in result.stdout
+
+    # Try to associate Alice's hotkey again with Alice's wallet
+    result = exec_command_alice(
+        command="wallet",
+        sub_command="associate-hotkey",
+        extra_args=[
+            "--wallet-path",
+            wallet_path_alice,
+            "--chain",
+            "ws://127.0.0.1:9945",
+            "--wallet-name",
+            wallet_alice.name,
+            "--wallet-hotkey",
+            wallet_alice.hotkey_str,
+            "--no-prompt",
+        ],
+    )
+
+    assert "is already associated with" in result.stdout
+    assert "wallet" in result.stdout
+    assert wallet_alice.name in result.stdout
+
+    # Associate Charlie's hotkey with Bob's wallet using SS58 address
+    result = exec_command_bob(
+        command="wallet",
+        sub_command="associate-hotkey",
+        extra_args=[
+            "--wallet-path",
+            wallet_path_bob,
+            "--chain",
+            "ws://127.0.0.1:9945",
+            "--wallet-name",
+            wallet_bob.name,
+            "--hotkey-ss58",
+            wallet_charlie.hotkey.ss58_address,
+            "--no-prompt",
+        ],
+    )
+
+    assert "Successfully associated hotkey" in result.stdout
+    assert wallet_charlie.hotkey.ss58_address in result.stdout
+    assert wallet_bob.coldkeypub.ss58_address in result.stdout
+
+    print("✅ Passed wallet associate-hotkey command")

--- a/tests/e2e_tests/test_wallet_interactions.py
+++ b/tests/e2e_tests/test_wallet_interactions.py
@@ -554,6 +554,7 @@ def test_wallet_associate_hotkey(local_chain, wallet_setup):
     assert "Successfully associated hotkey" in result.stdout
     assert wallet_alice.hotkey.ss58_address in result.stdout
     assert wallet_alice.coldkeypub.ss58_address in result.stdout
+    assert wallet_alice.hotkey_str in result.stdout
 
     # Try to associate Alice's hotkey with Bob's wallet (should fail)
     result = exec_command_bob(


### PR DESCRIPTION
- Adds new command `btcli wallet associate-hotkey`
- You can associate either with your wallet's hotkey or SS58 address. 