### PR TITLE
Allows for torch 2.6+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 
 [project.optional-dependencies]
 cuda = [
-    "torch>=1.13.1,<2.6.0",
+    "torch>=1.13.1,<3.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
We actually never had a reason to limit torch to <2.6.0 in btcli. We just copied this over from bittensor, where the limitation had to do with `torch.load`, but this isn't utilised whatsoever in btcli.