### PR TITLE
fix: IP range validation and improved error handling

### DIFF
--- a/bittensor_cli/src/bittensor/networking.py
+++ b/bittensor_cli/src/bittensor/networking.py
@@ -1,12 +1,18 @@
 import netaddr
 
-
 def int_to_ip(int_val: int) -> str:
-    """Maps an integer to a unique ip-string
-    :param int_val: The integer representation of an ip. Must be in the range (0, 3.4028237e+38).
+    """Maps an integer to a unique IP string.
+    
+    :param int_val: The integer representation of an IP. 
+        Must be in the range (0, 2^32-1) for IPv4 or (0, 2^128-1) for IPv6.
 
-    :return: The string representation of an ip. Of form *.*.*.* for ipv4 or *::*:*:*:* for ipv6
-
-    :raises: netaddr.core.AddrFormatError (Exception): Raised when the passed int_vals is not a valid ip int value.
+    :return: The string representation of an IP in the form *.*.*.* for IPv4 
+             or *::*:*:*:* for IPv6.
+    
+    :raises: netaddr.core.AddrFormatError: Raised when the passed int_val is 
+             not a valid IP integer value.
     """
-    return str(netaddr.IPAddress(int_val))
+    try:
+        return str(netaddr.IPAddress(int_val))
+    except netaddr.core.AddrFormatError as e:
+        raise ValueError(f"Invalid IP integer value: {int_val}") from e


### PR DESCRIPTION
I have corrected the ranges for both IPv4 and IPv6 to ensure they align with valid address formats.
Additionally, I’ve added a try-except block to better handle exceptions related to incorrect IP values. If an invalid IP is encountered, the error message is now more informative and easier to understand.