### PR TITLE
2 small help changes

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -259,14 +259,14 @@ class Options:
         "--slippage-tolerance",
         "--tolerance",
         "--rate-tolerance",
-        help="Set the rate tolerance percentage for transactions (default: 0.05%).",
+        help="Set the rate tolerance percentage for transactions (default: 0.05 for 5%).",
         callback=validate_rate_tolerance,
     )
     safe_staking = typer.Option(
         None,
         "--safe-staking/--no-safe-staking",
         "--safe/--unsafe",
-        help="Enable or disable safe staking mode (default: enabled).",
+        help="Enable or disable safe staking mode (default: disabled).",
     )
     allow_partial_stake = typer.Option(
         None,


### PR DESCRIPTION
The percentage was wrong on rate tolerance 0.05% - it is 5% or 0.05

For safe staking the default param is: [default: no-safe-staking] 
So the default is disabled.

Maybe the defaults should be removed from the text for easier maintenance - 2 default parameters is sort of weird:

`Enable or disable safe staking mode (default: enabled). [default: no-safe-staking] `