### PR TITLE
Fixes Error Formatter

### DIFF
--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -558,7 +558,11 @@ def format_error_message(error_message: Union[dict, Exception]) -> str:
             err_type = error_message.get("type", err_type)
             err_name = error_message.get("name", err_name)
             err_docs = error_message.get("docs", [err_description])
-            err_description = err_docs[0] if err_docs else err_description
+            if err_docs:
+                if isinstance(err_docs, list):
+                    err_description = err_docs[0]
+                else:
+                    err_description = err_docs
 
     return f"Subtensor returned `{err_name}({err_type})` error. This means: `{err_description}`."
 

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -558,11 +558,10 @@ def format_error_message(error_message: Union[dict, Exception]) -> str:
             err_type = error_message.get("type", err_type)
             err_name = error_message.get("name", err_name)
             err_docs = error_message.get("docs", [err_description])
-            if err_docs:
-                if isinstance(err_docs, list):
-                    err_description = err_docs[0]
-                else:
-                    err_description = err_docs
+            if isinstance(err_docs, list):
+                err_description = "; ".join(err_docs)
+            else:
+                err_description = err_docs
 
     return f"Subtensor returned `{err_name}({err_type})` error. This means: `{err_description}`."
 

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -559,7 +559,7 @@ def format_error_message(error_message: Union[dict, Exception]) -> str:
             err_name = error_message.get("name", err_name)
             err_docs = error_message.get("docs", [err_description])
             if isinstance(err_docs, list):
-                err_description = "; ".join(err_docs)
+                err_description = " ".join(err_docs)
             else:
                 err_description = err_docs
 


### PR DESCRIPTION
Fixes cases where err_docs is a string. We'll now get:

> ❌ Failed: Subtensor returned `BadOrigin(System)` error. This means: `Bad origin`.

instead of

> ❌ Failed: Subtensor returned `BadOrigin(System)` error. This means: `B`.