### PR TITLE
Fixes `test_staking_sudo` setting `max_burn`

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -4430,6 +4430,7 @@ class CLIManager:
         param_value: Optional[str] = typer.Option(
             "", "--value", help="Value to set the hyperparameter to."
         ),
+        prompt: bool = Options.prompt,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
         json_output: bool = Options.json_output,
@@ -4454,6 +4455,11 @@ class CLIManager:
                 raise typer.Exit()
 
         if not param_name:
+            if not prompt:
+                err_console.print(
+                    "Param name not supplied with `--no-prompt` flag. Cannot continue"
+                )
+                return False
             hyperparam_list = [field.name for field in fields(SubnetHyperparameters)]
             console.print("Available hyperparameters:\n")
             for idx, param in enumerate(hyperparam_list, start=1):
@@ -4467,6 +4473,11 @@ class CLIManager:
             param_name = hyperparam_list[choice - 1]
 
         if param_name in ["alpha_high", "alpha_low"]:
+            if not prompt:
+                err_console.print(
+                    "`alpha_high` and `alpha_low` values cannot be set with `--no-prompt`"
+                )
+                return False
             param_name = "alpha_values"
             low_val = FloatPrompt.ask(
                 "Enter the new value for [dark_orange]alpha_low[/dark_orange]"
@@ -4477,6 +4488,11 @@ class CLIManager:
             param_value = f"{low_val},{high_val}"
 
         if not param_value:
+            if not prompt:
+                err_console.print(
+                    "Param value not supplied with `--no-prompt` flag. Cannot continue."
+                )
+                return False
             if HYPERPARAMS.get(param_name):
                 param_value = Prompt.ask(
                     f"Enter the new value for [{COLORS.G.SUBHEAD}]{param_name}[/{COLORS.G.SUBHEAD}] "
@@ -4495,6 +4511,7 @@ class CLIManager:
                 netuid,
                 param_name,
                 param_value,
+                prompt,
                 json_output,
             )
         )

--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -640,7 +640,7 @@ HYPERPARAMS = {
     "activity_cutoff": ("sudo_set_activity_cutoff", False),
     "target_regs_per_interval": ("sudo_set_target_registrations_per_interval", True),
     "min_burn": ("sudo_set_min_burn", True),
-    "max_burn": ("sudo_set_max_burn", False),
+    "max_burn": ("sudo_set_max_burn", True),
     "bonds_moving_avg": ("sudo_set_bonds_moving_average", False),
     "max_regs_per_block": ("sudo_set_max_registrations_per_block", True),
     "serving_rate_limit": ("sudo_set_serving_rate_limit", False),

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -145,6 +145,7 @@ async def set_hyperparameter_extrinsic(
     value: Optional[Union[str, bool, float, list[float]]],
     wait_for_inclusion: bool = False,
     wait_for_finalization: bool = True,
+    prompt: bool = True,
 ) -> bool:
     """Sets a hyperparameter for a specific subnetwork.
 
@@ -190,7 +191,7 @@ async def set_hyperparameter_extrinsic(
                 ":cross_mark: [red]Invalid hyperparameter specified.[/red]"
             )
             return False
-    if sudo_:
+    if sudo_ and prompt:
         if not Confirm.ask(
             "This hyperparam is only settable by root sudo users. If you are not, this will fail. Please confirm"
         ):
@@ -574,6 +575,7 @@ async def sudo_set_hyperparameter(
     netuid: int,
     param_name: str,
     param_value: Optional[str],
+    prompt: bool,
     json_output: bool,
 ):
     """Set subnet hyperparameters."""
@@ -602,7 +604,7 @@ async def sudo_set_hyperparameter(
         )
         return False
     success = await set_hyperparameter_extrinsic(
-        subtensor, wallet, netuid, param_name, value
+        subtensor, wallet, netuid, param_name, value, prompt=prompt
     )
     if json_output:
         return success

--- a/tests/e2e_tests/test_staking_sudo.py
+++ b/tests/e2e_tests/test_staking_sudo.py
@@ -339,6 +339,7 @@ def test_staking(local_chain, wallet_setup):
             "max_burn",
             "--value",
             "10000000000",  # In RAO, TAO = 10
+            "--no-prompt",
         ],
     )
     assert (


### PR DESCRIPTION
Allows for passing stake sudo test because `max_burn` hyperparam is now root sudo only.

See https://github.com/opentensor/subtensor/pull/1573