### PR TITLE
Lengthen default era period + rename "era" to "period"

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -294,7 +294,7 @@ class Options:
         help="Outputs the result of the command as JSON.",
     )
     era: int = typer.Option(
-        3, help="Length (in blocks) for which the transaction should be valid."
+        10, help="Length (in blocks) for which the transaction should be valid."
     )
 
 

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -294,7 +294,7 @@ class Options:
         help="Outputs the result of the command as JSON.",
     )
     period: int = typer.Option(
-        10,
+        16,
         "--period",
         "--era",
         help="Length (in blocks) for which the transaction should be valid.",

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -293,8 +293,11 @@ class Options:
         "--json-out",
         help="Outputs the result of the command as JSON.",
     )
-    era: int = typer.Option(
-        10, help="Length (in blocks) for which the transaction should be valid."
+    period: int = typer.Option(
+        10,
+        "--period",
+        "--era",
+        help="Length (in blocks) for which the transaction should be valid.",
     )
 
 
@@ -1792,7 +1795,7 @@ class CLIManager:
         transfer_all: bool = typer.Option(
             False, "--all", prompt=False, help="Transfer all available balance."
         ),
-        era: int = Options.era,
+        period: int = Options.period,
         wallet_name: str = Options.wallet_name,
         wallet_path: str = Options.wallet_path,
         wallet_hotkey: str = Options.wallet_hotkey,
@@ -1847,7 +1850,7 @@ class CLIManager:
                 destination=destination_ss58_address,
                 amount=amount,
                 transfer_all=transfer_all,
-                era=era,
+                era=period,
                 prompt=prompt,
                 json_output=json_output,
             )
@@ -3190,7 +3193,7 @@ class CLIManager:
         rate_tolerance: Optional[float] = Options.rate_tolerance,
         safe_staking: Optional[bool] = Options.safe_staking,
         allow_partial_stake: Optional[bool] = Options.allow_partial_stake,
-        era: int = Options.era,
+        period: int = Options.period,
         prompt: bool = Options.prompt,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
@@ -3386,7 +3389,7 @@ class CLIManager:
                 rate_tolerance,
                 allow_partial_stake,
                 json_output,
-                era,
+                period,
             )
         )
 
@@ -3438,7 +3441,7 @@ class CLIManager:
         rate_tolerance: Optional[float] = Options.rate_tolerance,
         safe_staking: Optional[bool] = Options.safe_staking,
         allow_partial_stake: Optional[bool] = Options.allow_partial_stake,
-        era: int = Options.era,
+        period: int = Options.period,
         prompt: bool = Options.prompt,
         interactive: bool = typer.Option(
             False,
@@ -3631,7 +3634,7 @@ class CLIManager:
                     exclude_hotkeys=exclude_hotkeys,
                     prompt=prompt,
                     json_output=json_output,
-                    era=era,
+                    era=period,
                 )
             )
         elif (
@@ -3687,7 +3690,7 @@ class CLIManager:
                 rate_tolerance=rate_tolerance,
                 allow_partial_stake=allow_partial_stake,
                 json_output=json_output,
-                era=era,
+                era=period,
             )
         )
 
@@ -3715,7 +3718,7 @@ class CLIManager:
         stake_all: bool = typer.Option(
             False, "--stake-all", "--all", help="Stake all", prompt=False
         ),
-        era: int = Options.era,
+        period: int = Options.period,
         prompt: bool = Options.prompt,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
@@ -3845,7 +3848,7 @@ class CLIManager:
                 destination_hotkey=destination_hotkey,
                 amount=amount,
                 stake_all=stake_all,
-                era=era,
+                era=period,
                 interactive_selection=interactive_selection,
                 prompt=prompt,
             )
@@ -3886,7 +3889,7 @@ class CLIManager:
         stake_all: bool = typer.Option(
             False, "--stake-all", "--all", help="Stake all", prompt=False
         ),
-        era: int = Options.era,
+        period: int = Options.period,
         prompt: bool = Options.prompt,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
@@ -4008,7 +4011,7 @@ class CLIManager:
                 dest_netuid=dest_netuid,
                 dest_coldkey_ss58=dest_ss58,
                 amount=amount,
-                era=era,
+                era=period,
                 interactive_selection=interactive_selection,
                 stake_all=stake_all,
                 prompt=prompt,
@@ -4050,7 +4053,7 @@ class CLIManager:
             "--all",
             help="Swap all available stake",
         ),
-        era: int = Options.era,
+        period: int = Options.period,
         prompt: bool = Options.prompt,
         wait_for_inclusion: bool = Options.wait_for_inclusion,
         wait_for_finalization: bool = Options.wait_for_finalization,
@@ -4115,7 +4118,7 @@ class CLIManager:
                 destination_netuid=dest_netuid,
                 amount=amount,
                 swap_all=swap_all,
-                era=era,
+                era=period,
                 interactive_selection=interactive_selection,
                 prompt=prompt,
                 wait_for_inclusion=wait_for_inclusion,
@@ -5275,10 +5278,12 @@ class CLIManager:
         wallet_hotkey: str = Options.wallet_hotkey,
         network: Optional[list[str]] = Options.network,
         netuid: int = Options.netuid,
-        era: Optional[
+        period: Optional[
             int
-        ] = typer.Option(  # Should not be Options.era bc this needs to be an Optional[int]
+        ] = typer.Option(  # Should not be Options.period bc this needs to be an Optional[int]
             None,
+            "--period",
+            "--era",
             help="Length (in blocks) for which the transaction should be valid. Note that it is possible that if you "
             "use an era for this transaction that you may pay a different fee to register than the one stated.",
         ),
@@ -5311,7 +5316,7 @@ class CLIManager:
                 wallet,
                 self.initialize_chain(network),
                 netuid,
-                era,
+                period,
                 json_output,
                 prompt,
             )


### PR DESCRIPTION
Fixes #441 by lengthening era period to 16 blocks (era periods must be powers of two)

Also renames `era` param to `period` (with a backwards-compatible alias of `--era`) to keep consistent with the SDK naming.