### PR TITLE
click version 8.2.0 broken

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ dependencies = [
     "async-substrate-interface>=1.1.0",
     "aiohttp~=3.10.2",
     "backoff~=2.2.1",
+    "click<8.2.0",  # typer.testing.CliRunner(mix_stderr=) is broken in click 8.2.0+
     "GitPython>=3.0.0",
     "fuzzywuzzy~=0.18.0",
     "netaddr~=1.3.0",


### PR DESCRIPTION
[Click 8.2.0](https://github.com/pallets/click/releases/tag/8.2.0)

> Keep stdout and stderr streams independent in CliRunner. Always collect stderr output and never raise an exception. Add a new output stream to simulate what the user sees in its terminal. Removes the mix_stderr parameter in CliRunner. #2522 #2523

Drops the keyword `mix_stderr` for `CliRunner`. This is used in `btcli/tests/e2e_tests/utils.py`:
```python
runner = CliRunner(mix_stderr=False)
```

Pins the version as under 8.2.0 for now.