### PR TITLE
Subnets Register Improvements

### DIFF
--- a/bittensor_cli/src/bittensor/extrinsics/registration.py
+++ b/bittensor_cli/src/bittensor/extrinsics/registration.py
@@ -678,7 +678,6 @@ async def burned_register_extrinsic(
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = True,
     era: Optional[int] = None,
-    prompt: bool = False,
 ) -> tuple[bool, str]:
     """Registers the wallet to chain by recycling TAO.
 

--- a/bittensor_cli/src/bittensor/extrinsics/root.py
+++ b/bittensor_cli/src/bittensor/extrinsics/root.py
@@ -290,7 +290,6 @@ async def root_register_extrinsic(
     wallet: Wallet,
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = True,
-    prompt: bool = False,
 ) -> tuple[bool, str]:
     r"""Registers the wallet to root network.
 

--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -1656,15 +1656,12 @@ async def register(
             return
 
     if netuid == 0:
-        success, msg = await root_register_extrinsic(
-            subtensor, wallet=wallet, prompt=prompt
-        )
+        success, msg = await root_register_extrinsic(subtensor, wallet=wallet)
     else:
         success, msg = await burned_register_extrinsic(
             subtensor,
             wallet=wallet,
             netuid=netuid,
-            prompt=prompt,
             old_balance=balance,
             era=era,
         )

--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -1668,6 +1668,9 @@ async def register(
         )
     if json_output:
         json_console.print(json.dumps({"success": success, "msg": msg}))
+    else:
+        if not success:
+            err_console.print(f"Failure: {msg}")
 
 
 # TODO: Confirm emissions, incentive, Dividends are to be fetched from subnet_state or keep NeuronInfo

--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -1656,13 +1656,15 @@ async def register(
             return
 
     if netuid == 0:
-        success, msg = await root_register_extrinsic(subtensor, wallet=wallet)
+        success, msg = await root_register_extrinsic(
+            subtensor, wallet=wallet, prompt=prompt
+        )
     else:
         success, msg = await burned_register_extrinsic(
             subtensor,
             wallet=wallet,
             netuid=netuid,
-            prompt=False,
+            prompt=prompt,
             old_balance=balance,
             era=era,
         )


### PR DESCRIPTION
- Now handles situations where failures occur in `root_register_extrinsic` and `burned_register_extrinsic`, but the user is not using `--json-output`, and correctly prints out the error.
- Removes `prompt` arg from `root_register_extrinsic` & `burned_register_extrinsic`, as the prompt was unused, and was already handled in `subnets.register`.