### PR TITLE
Fix `KeyFileError: File is not writable` during `btcli wallet create` command

### DIFF
--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -438,11 +438,10 @@ async def wallet_create(
                 "name": wallet.name,
                 "path": wallet.path,
                 "hotkey": wallet.hotkey_str,
-                "hotkey_ss58": wallet.hotkey.ss58_address,
                 "coldkey_ss58": wallet.coldkeypub.ss58_address,
             }
-        except KeyFileError:
-            err = "KeyFileError: File is not writable"
+        except KeyFileError as error:
+            err = str(error)
             print_error(err)
             output_dict["error"] = err
         try:
@@ -458,10 +457,9 @@ async def wallet_create(
                 "path": wallet.path,
                 "hotkey": wallet.hotkey_str,
                 "hotkey_ss58": wallet.hotkey.ss58_address,
-                "coldkey_ss58": wallet.coldkeypub.ss58_address,
             }
-        except KeyFileError:
-            err = "KeyFileError: File is not writable"
+        except KeyFileError as error:
+            err = str(error)
             print_error(err)
             output_dict["error"] = err
     if json_output:


### PR DESCRIPTION
The error `KeyFileError: File is not writable` is not valid. The real error was accessing fields that do not exist in the wallet object at a certain step.

Contains:
- removed references to non-existent fields
- added valid error messages