### PR TITLE
hyperparam bool fix

### DIFF
--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -92,6 +92,8 @@ def search_metadata(
     """
 
     def string_to_bool(val) -> bool:
+        if isinstance(val, bool):
+            return val
         try:
             return {"true": True, "1": True, "0": False, "false": False}[val.lower()]
         except KeyError:
@@ -115,6 +117,7 @@ def search_metadata(
     for pallet in metadata.pallets:
         if pallet.name == "AdminUtils":
             for call in pallet.calls:
+                print(call.name)
                 if call.name == param_name:
                     if "netuid" not in [x.name for x in call.args]:
                         return False, None


### PR DESCRIPTION
Fixes a situation where specifying "True" or "False", rather than "true", "false", "1", "0", in hyperparam setting results in a type error. 
As this previously gets already changed to a bool in line 596:
```py
    elif param_value in ("True", "False"):
        normalized_value = {
            "True": True,
            "False": False,
        }[param_value]
```