### PR TITLE
Adds `alpha_sigmoid_steepness` call for hyperparams set/get

### DIFF
--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -659,6 +659,7 @@ HYPERPARAMS = {
         False,
     ),
     "yuma3_enabled": ("sudo_set_yuma3_enabled", False),
+    "alpha_sigmoid_steepness": ("sudo_set_alpha_sigmoid_steepness", True),
 }
 
 # Help Panels for cli help

--- a/bittensor_cli/src/bittensor/chain_data.py
+++ b/bittensor_cli/src/bittensor/chain_data.py
@@ -178,6 +178,7 @@ class SubnetHyperparameters(InfoBase):
     alpha_low: int
     liquid_alpha_enabled: bool
     yuma3_enabled: bool
+    alpha_sigmoid_steepness: int
 
     @classmethod
     def _fix_decoded(
@@ -212,6 +213,7 @@ class SubnetHyperparameters(InfoBase):
             alpha_low=decoded.get("alpha_low"),
             liquid_alpha_enabled=decoded.get("liquid_alpha_enabled"),
             yuma3_enabled=decoded.get("yuma3_enabled"),
+            alpha_sigmoid_steepness=decoded.get("alpha_sigmoid_steepness"),
         )
 
 

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -1128,7 +1128,7 @@ class SubtensorInterface:
         Understanding the hyperparameters is crucial for comprehending how subnets are configured and
         managed, and how they interact with the network's consensus and incentive mechanisms.
         """
-        main_result, yuma3_result = await asyncio.gather(
+        main_result, yuma3_result, sigmoid_steepness = await asyncio.gather(
             self.query_runtime_api(
                 runtime_api="SubnetInfoRuntimeApi",
                 method="get_subnet_hyperparams",
@@ -1136,9 +1136,13 @@ class SubtensorInterface:
                 block_hash=block_hash,
             ),
             self.query("SubtensorModule", "Yuma3On", [netuid]),
+            self.query("SubtensorModule", "AlphaSigmoidSteepness", [netuid]),
         )
-        result = {**main_result, **{"yuma3_enabled": yuma3_result}}
-
+        result = {
+            **main_result,
+            **{"yuma3_enabled": yuma3_result},
+            **{"alpha_sigmoid_steepness": sigmoid_steepness},
+        }
         if not main_result:
             return []
 

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -739,6 +739,7 @@ def normalize_hyperparameters(
         "kappa": u16_normalized_float,
         "alpha_high": u16_normalized_float,
         "alpha_low": u16_normalized_float,
+        "alpha_sigmoid_steepness": u16_normalized_float,
         "min_burn": Balance.from_rao,
         "max_burn": Balance.from_rao,
     }


### PR DESCRIPTION
Rhef states anyone who wants to use Yuma 3 will likely want to set this, but it's a root sudo only call, so I need to confirm with @camfairchild and @ppolewicz 