### PR TITLE
subnets check-start formatting blocks

### DIFF
--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -2323,7 +2323,7 @@ async def get_start_schedule(
         print_error(f"Subnet {netuid} does not exist.")
         return None
     block_hash = await subtensor.substrate.get_chain_head()
-    registration_block, min_blocks_to_start, current_block = await asyncio.gather(
+    registration_block, min_blocks_to_start_, current_block = await asyncio.gather(
         subtensor.query(
             module="SubtensorModule",
             storage_function="NetworkRegisteredAt",
@@ -2337,6 +2337,7 @@ async def get_start_schedule(
         ),
         subtensor.substrate.get_block_number(block_hash=block_hash),
     )
+    min_blocks_to_start = getattr(min_blocks_to_start_, "value", min_blocks_to_start_)
 
     potential_start_block = registration_block + min_blocks_to_start
     if current_block < potential_start_block:


### PR DESCRIPTION
Fixes BittensorScaleType:

Before:
```
⚡ btcli s check-start --netuid 117 --network finney
5710859 BittensorScaleType(value=50400)> 5750992
Subnet 117:
Registered at: 5710859
Minimum start block: BittensorScaleType(value=5761259)>
Current block: 5750992
Blocks remaining: BittensorScaleType(value=10267)>
Time to wait: BittensorScaleType(value=1)>d BittensorScaleType(value=10)>h
```

After this:
```
⚡ btcli s check-start --netuid 117 --network finney
Subnet 117:
Registered at: 5710859
Minimum start block: 5761259
Current block: 5750997
Blocks remaining: 10262
Time to wait: 1d 10h
```