### PR TITLE
Updates safe staking/unstaking limits

### DIFF
--- a/bittensor_cli/src/commands/stake/add.py
+++ b/bittensor_cli/src/commands/stake/add.py
@@ -342,14 +342,14 @@ async def stake_add(
             # If we are staking safe, add price tolerance
             if safe_staking:
                 if subnet_info.is_dynamic:
-                    rate = 1 / subnet_info.price.tao or 1
+                    rate = amount_to_stake.rao / received_amount.rao
                     _rate_with_tolerance = rate * (
                         1 + rate_tolerance
                     )  # Rate only for display
                     rate_with_tolerance = f"{_rate_with_tolerance:.4f}"
-                    price_with_tolerance = subnet_info.price.rao * (
-                        1 + rate_tolerance
-                    )  # Actual price to pass to extrinsic
+                    price_with_tolerance = Balance.from_tao(
+                        _rate_with_tolerance
+                    ).rao  # Actual price to pass to extrinsic
                 else:
                     rate_with_tolerance = "1"
                     price_with_tolerance = Balance.from_rao(1)

--- a/bittensor_cli/src/commands/stake/remove.py
+++ b/bittensor_cli/src/commands/stake/remove.py
@@ -248,7 +248,7 @@ async def unstake(
             # Additional fields for safe unstaking
             if safe_staking:
                 if subnet_info.is_dynamic:
-                    rate = amount_to_unstake_as_balance.rao / received_amount.rao
+                    rate = received_amount.rao / amount_to_unstake_as_balance.rao
                     rate_with_tolerance = rate * (
                         1 - rate_tolerance
                     )  # Rate only for display

--- a/bittensor_cli/src/commands/stake/remove.py
+++ b/bittensor_cli/src/commands/stake/remove.py
@@ -248,13 +248,13 @@ async def unstake(
             # Additional fields for safe unstaking
             if safe_staking:
                 if subnet_info.is_dynamic:
-                    rate = subnet_info.price.tao or 1
+                    rate = amount_to_unstake_as_balance.rao / received_amount.rao
                     rate_with_tolerance = rate * (
                         1 - rate_tolerance
                     )  # Rate only for display
-                    price_with_tolerance = subnet_info.price.rao * (
-                        1 - rate_tolerance
-                    )  # Actual price to pass to extrinsic
+                    price_with_tolerance = Balance.from_tao(
+                        rate_with_tolerance
+                    ).rao  # Actual price to pass to extrinsic
                 else:
                     rate_with_tolerance = 1
                     price_with_tolerance = 1


### PR DESCRIPTION
- received_amount already goes thru the conversion `_calculate_slippage` and when it hits `tao_to_alpha_with_slippage`
![image](https://github.com/user-attachments/assets/4732b222-c0d0-445c-989a-5040f204a3a0)
![image](https://github.com/user-attachments/assets/596157e8-bbcd-4d87-b420-f93fc88df85a)
![image](https://github.com/user-attachments/assets/90f90f53-ee25-48a5-be35-d7240bdcb522)
- Conversion to `rao` so we can pass into subtensor in the end