### PR TITLE
Update docs URL

### DIFF
--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from bittensor_cli.src.bittensor.chain_data import SubnetHyperparameters
     from rich.prompt import PromptBase
 
-BT_DOCS_LINK = "https://docs.bittensor.com"
+BT_DOCS_LINK = "https://docs.learnbittensor.org"
 
 
 console = Console()


### PR DESCRIPTION
Updates `docs.bittensor.com` to its new location at `docs.learnbittensor.org`