### PR TITLE
Patches broken Brahmi characters with normal characters.

### DIFF
--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -323,6 +323,18 @@ async def subnets_list(
 
         for subnet in subnets_:
             netuid = subnet.netuid
+            # The symbols for 123 and 124 are visually identical:
+            # 123:  𑀀
+            # 124:  𑀁
+            # and the symbol for 125 is basically a colon
+            # 125:  𑀂
+            # however, because they're in Brahmi, which very few fonts support, they don't render properly
+            # This patches them.
+            if netuid == 125:
+                subnet.symbol = ":"
+            elif netuid in (124, 123):
+                subnet.symbol = "˙"
+
             symbol = f"{subnet.symbol}\u200e"
 
             if netuid == 0:

--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -323,17 +323,16 @@ async def subnets_list(
 
         for subnet in subnets_:
             netuid = subnet.netuid
-            # The symbols for 123 and 124 are visually identical:
+            # The default symbols for 123 and 124 are visually identical:
             # 123:  𑀀
             # 124:  𑀁
             # and the symbol for 125 is basically a colon
             # 125:  𑀂
             # however, because they're in Brahmi, which very few fonts support, they don't render properly
             # This patches them.
-            if netuid == 125:
-                subnet.symbol = ":"
-            elif netuid in (124, 123):
-                subnet.symbol = "˙"
+            replacements = {69632: "˙", 69633: "˙", 69634: ":"}
+            if (sso := ord(subnet.symbol)) in replacements.keys():
+                subnet.symbol = replacements[sso]
 
             symbol = f"{subnet.symbol}\u200e"
 


### PR DESCRIPTION
This is how the symbols should appear:
<img width="268" height="150" alt="Screenshot 2025-07-16 at 18 08 31" src="https://github.com/user-attachments/assets/aa7f2378-86ca-4d30-8d16-9248223a5fbb" />

This is how they actually do render on virtually every normally-used font:
<img width="546" height="740" alt="Screenshot 2025-07-16 at 18 09 10" src="https://github.com/user-attachments/assets/2bda79e3-4bb9-4261-b226-cb0d3db28d81" />


This fix patches them to their visual equivalents:
<img width="616" height="864" alt="Screenshot 2025-07-16 at 18 22 51" src="https://github.com/user-attachments/assets/af99d320-6791-44d5-8838-fef01e184fe5" />
