### PR TITLE
Sets default interval hours for subnets price to 4, bc of rate limiting.

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -5009,7 +5009,7 @@ class CLIManager:
             "Netuids to show the price for. Separate multiple netuids with a comma, for example: `-n 0,1,2`.",
         ),
         interval_hours: int = typer.Option(
-            24,
+            4,
             "--interval-hours",
             "--interval",
             help="The number of hours to show the historical price for.",

--- a/bittensor_cli/src/commands/subnets/price.py
+++ b/bittensor_cli/src/commands/subnets/price.py
@@ -27,7 +27,7 @@ async def price(
     subtensor: "SubtensorInterface",
     netuids: list[int],
     all_netuids: bool = False,
-    interval_hours: int = 24,
+    interval_hours: int = 4,
     html_output: bool = False,
     log_scale: bool = False,
     json_output: bool = False,


### PR DESCRIPTION
There's no good way of querying block hashes in a way that doesn't go over the OTF archive rate limit. So we'll just set the default to 4.