### PR TITLE
Subnets Price --current + improvements

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1061,32 +1061,35 @@ class CLIManager:
                 "Verify this is intended.",
             )
             if not self.subtensor:
-                if network:
-                    network_ = None
-                    for item in network:
-                        if item.startswith("ws"):
-                            network_ = item
-                            break
-                        else:
-                            network_ = item
-
-                    not_selected_networks = [net for net in network if net != network_]
-                    if not_selected_networks:
-                        console.print(
-                            f"Networks not selected: "
-                            f"[{COLORS.G.ARG}]{', '.join(not_selected_networks)}[/{COLORS.G.ARG}]"
-                        )
-
-                    self.subtensor = SubtensorInterface(network_)
-                elif self.config["network"]:
-                    self.subtensor = SubtensorInterface(self.config["network"])
-                    console.print(
-                        f"Using the specified network [{COLORS.G.LINKS}]{self.config['network']}"
-                        f"[/{COLORS.G.LINKS}] from config"
-                    )
-                else:
-                    self.subtensor = SubtensorInterface(defaults.subtensor.network)
+                self.subtensor = SubtensorInterface(self._determine_network(network))
         return self.subtensor
+
+    def _determine_network(self, network: Optional[list[str]] = None):
+        if network:
+            network_ = None
+            for item in network:
+                if item.startswith("ws"):
+                    network_ = item
+                    break
+                else:
+                    network_ = item
+
+            not_selected_networks = [net for net in network if net != network_]
+            if not_selected_networks:
+                console.print(
+                    f"Networks not selected: "
+                    f"[{COLORS.G.ARG}]{', '.join(not_selected_networks)}[/{COLORS.G.ARG}]"
+                )
+
+            return network_
+        elif self.config["network"]:
+            console.print(
+                f"Using the specified network [{COLORS.G.LINKS}]{self.config['network']}"
+                f"[/{COLORS.G.LINKS}] from config"
+            )
+            return self.config["network"]
+        else:
+            return defaults.subtensor.network
 
     def _run_command(self, cmd: Coroutine, exit_early: bool = True):
         """

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -5026,6 +5026,11 @@ class CLIManager:
             "--log",
             help="Show the price in log scale.",
         ),
+        current_only: bool = typer.Option(
+            False,
+            "--current",
+            help="Show only the current data, and no historical data.",
+        ),
         html_output: bool = Options.html_output,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
@@ -5050,6 +5055,17 @@ class CLIManager:
         if json_output and html_output:
             print_error("Cannot specify both `--json-output` and `--html`")
             return
+        non_archives = ["finney", "latent-lite", "subvortex"]
+        if not current_only and self._determine_network(network) in non_archives + [
+            Constants.network_map[x] for x in non_archives
+        ]:
+            err_console.print(
+                f"[red]Error[/red] Running this command without [{COLORS.G.ARG}]--current[/{COLORS.G.ARG}] requires "
+                "use of an archive node. "
+                f"Try running again with the [{COLORS.G.ARG}]--network archive[/{COLORS.G.ARG}] flag."
+            )
+            return False
+
         self.verbosity_handler(quiet=quiet, verbose=verbose, json_output=json_output)
         if netuids:
             netuids = parse_to_list(
@@ -5084,6 +5100,7 @@ class CLIManager:
                 netuids,
                 all_netuids,
                 interval_hours,
+                current_only,
                 html_output,
                 log_scale,
                 json_output,

--- a/bittensor_cli/src/commands/subnets/price.py
+++ b/bittensor_cli/src/commands/subnets/price.py
@@ -10,6 +10,7 @@ import plotille
 import plotly.graph_objects as go
 
 from bittensor_cli.src import COLOR_PALETTE
+from bittensor_cli.src.bittensor.chain_data import DynamicInfo
 from bittensor_cli.src.bittensor.utils import (
     console,
     err_console,
@@ -28,6 +29,7 @@ async def price(
     netuids: list[int],
     all_netuids: bool = False,
     interval_hours: int = 4,
+    current_only: bool = False,
     html_output: bool = False,
     log_scale: bool = False,
     json_output: bool = False,
@@ -41,45 +43,93 @@ async def price(
     blocks_per_hour = int(3600 / 12)  # ~300 blocks per hour
     total_blocks = blocks_per_hour * interval_hours
 
-    with console.status(":chart_increasing: Fetching historical price data..."):
-        current_block_hash = await subtensor.substrate.get_chain_head()
-        current_block = await subtensor.substrate.get_block_number(current_block_hash)
+    if not current_only:
+        with console.status(":chart_increasing: Fetching historical price data..."):
+            current_block_hash = await subtensor.substrate.get_chain_head()
+            current_block = await subtensor.substrate.get_block_number(
+                current_block_hash
+            )
 
-        step = 300
-        start_block = max(0, current_block - total_blocks)
-        block_numbers = list(range(start_block, current_block + 1, step))
+            step = 300
+            start_block = max(0, current_block - total_blocks)
+            block_numbers = list(range(start_block, current_block + 1, step))
 
-        # Block hashes
-        block_hash_cors = [
-            subtensor.substrate.get_block_hash(bn) for bn in block_numbers
-        ]
-        block_hashes = await asyncio.gather(*block_hash_cors)
+            # Block hashes
+            block_hash_cors = [
+                subtensor.substrate.get_block_hash(bn) for bn in block_numbers
+            ]
+            block_hashes = await asyncio.gather(*block_hash_cors)
 
-        # We fetch all subnets when there is more than one netuid
-        if all_netuids or len(netuids) > 1:
-            subnet_info_cors = [subtensor.all_subnets(bh) for bh in block_hashes]
-        else:
-            # If there is only one netuid, we fetch the subnet info for that netuid
-            netuid = netuids[0]
-            subnet_info_cors = [subtensor.subnet(netuid, bh) for bh in block_hashes]
-        all_subnet_infos = await asyncio.gather(*subnet_info_cors)
+            # We fetch all subnets when there is more than one netuid
+            if all_netuids or len(netuids) > 1:
+                subnet_info_cors = [subtensor.all_subnets(bh) for bh in block_hashes]
+            else:
+                # If there is only one netuid, we fetch the subnet info for that netuid
+                netuid = netuids[0]
+                subnet_info_cors = [subtensor.subnet(netuid, bh) for bh in block_hashes]
+            all_subnet_infos = await asyncio.gather(*subnet_info_cors)
 
         subnet_data = _process_subnet_data(
             block_numbers, all_subnet_infos, netuids, all_netuids
         )
+        if not subnet_data:
+            err_console.print("[red]No valid price data found for any subnet[/red]")
+            return
 
-    if not subnet_data:
-        err_console.print("[red]No valid price data found for any subnet[/red]")
-        return
-
-    if html_output:
-        await _generate_html_output(
-            subnet_data, block_numbers, interval_hours, log_scale
-        )
-    elif json_output:
-        json_console.print(json.dumps(_generate_json_output(subnet_data)))
+        if html_output:
+            await _generate_html_output(
+                subnet_data, block_numbers, interval_hours, log_scale
+            )
+        elif json_output:
+            json_console.print(json.dumps(_generate_json_output(subnet_data)))
+        else:
+            _generate_cli_output(subnet_data, block_numbers, interval_hours, log_scale)
     else:
-        _generate_cli_output(subnet_data, block_numbers, interval_hours, log_scale)
+        with console.status("Fetching current price data..."):
+            if all_netuids or len(netuids) > 1:
+                all_subnet_info = await subtensor.all_subnets()
+            else:
+                all_subnet_info = [await subtensor.subnet(netuid=netuids[0])]
+        subnet_data = _process_current_subnet_data(
+            all_subnet_info, netuids, all_netuids
+        )
+        _generate_cli_output_current(subnet_data)
+
+
+def _process_current_subnet_data(subnet_infos: list[DynamicInfo], netuids, all_netuids):
+    subnet_data = {}
+    if all_netuids or len(netuids) > 1:
+        # Most recent data for statistics
+        for subnet_info in subnet_infos:
+            stats = {
+                "current_price": subnet_info.price,
+                "supply": subnet_info.alpha_in.tao + subnet_info.alpha_out.tao,
+                "market_cap": subnet_info.price.tao
+                * (subnet_info.alpha_in.tao + subnet_info.alpha_out.tao),
+                "emission": subnet_info.emission.tao,
+                "stake": subnet_info.alpha_out.tao,
+                "symbol": subnet_info.symbol,
+                "name": get_subnet_name(subnet_info),
+            }
+            subnet_data[subnet_info.netuid] = {
+                "stats": stats,
+            }
+    else:
+        subnet_info = subnet_infos[0]
+        stats = {
+            "current_price": subnet_info.price,
+            "supply": subnet_info.alpha_in.tao + subnet_info.alpha_out.tao,
+            "market_cap": subnet_info.price.tao
+            * (subnet_info.alpha_in.tao + subnet_info.alpha_out.tao),
+            "emission": subnet_info.emission.tao,
+            "stake": subnet_info.alpha_out.tao,
+            "symbol": subnet_info.symbol,
+            "name": get_subnet_name(subnet_info),
+        }
+        subnet_data[subnet_info.netuid] = {
+            "stats": stats,
+        }
+    return subnet_data
 
 
 def _process_subnet_data(block_numbers, all_subnet_infos, netuids, all_netuids):
@@ -623,6 +673,49 @@ def _generate_cli_output(subnet_data, block_numbers, interval_hours, log_scale):
                 f"{stats['symbol']} {stats['emission']:,.2f}[/{COLOR_PALETTE['POOLS']['EMISSION']}]\n"
                 f"Stake: [{COLOR_PALETTE['STAKE']['TAO']}]"
                 f"{stats['symbol']} {stats['stake']:,.2f}[/{COLOR_PALETTE['STAKE']['TAO']}]"
+            )
+
+        console.print(stats_text)
+
+
+def _generate_cli_output_current(subnet_data):
+    for netuid, data in subnet_data.items():
+        stats = data["stats"]
+
+        if netuid != 0:
+            console.print(
+                f"\n[{COLOR_PALETTE.G.SYM}]Subnet {netuid} - {stats['symbol']} "
+                f"[cyan]{stats['name']}[/cyan][/{COLOR_PALETTE.G.SYM}]\n"
+                f"Current: [blue]{stats['current_price'].tao:.6f}{stats['symbol']}[/blue]\n"
+            )
+        else:
+            console.print(
+                f"\n[{COLOR_PALETTE.G.SYM}]Subnet {netuid} - {stats['symbol']} "
+                f"[cyan]{stats['name']}[/cyan][/{COLOR_PALETTE.G.SYM}]\n"
+                f"Current: [blue]{stats['symbol']} {stats['current_price'].tao:.6f}[/blue]\n"
+            )
+
+        if netuid != 0:
+            stats_text = (
+                "\nLatest stats:\n"
+                f"Supply: [{COLOR_PALETTE.P.ALPHA_IN}]"
+                f"{stats['supply']:,.2f} {stats['symbol']}[/{COLOR_PALETTE.P.ALPHA_IN}]\n"
+                f"Market Cap: [steel_blue3]{stats['market_cap']:,.2f} {stats['symbol']} / 21M[/steel_blue3]\n"
+                f"Emission: [{COLOR_PALETTE.P.EMISSION}]"
+                f"{stats['emission']:,.2f} {stats['symbol']}[/{COLOR_PALETTE.P.EMISSION}]\n"
+                f"Stake: [{COLOR_PALETTE.S.TAO}]"
+                f"{stats['stake']:,.2f} {stats['symbol']}[/{COLOR_PALETTE.S.TAO}]"
+            )
+        else:
+            stats_text = (
+                "\nLatest stats:\n"
+                f"Supply: [{COLOR_PALETTE.P.ALPHA_IN}]"
+                f"{stats['symbol']} {stats['supply']:,.2f}[/{COLOR_PALETTE.P.ALPHA_IN}]\n"
+                f"Market Cap: [steel_blue3]{stats['symbol']} {stats['market_cap']:,.2f} / 21M[/steel_blue3]\n"
+                f"Emission: [{COLOR_PALETTE.P.EMISSION}]"
+                f"{stats['symbol']} {stats['emission']:,.2f}[/{COLOR_PALETTE.P.EMISSION}]\n"
+                f"Stake: [{COLOR_PALETTE.S.TAO}]"
+                f"{stats['symbol']} {stats['stake']:,.2f}[/{COLOR_PALETTE.S.TAO}]"
             )
 
         console.print(stats_text)


### PR DESCRIPTION
`btcli s price` fails if you use a non-archive node. 

There are now two ways of getting around this. You can pass the `--current` flag to only get current data, and if you don't, the btcli immediately warns you if you are not using an archive node.