### PR TITLE
Specify click version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "async-substrate-interface>=1.4.2",
     "aiohttp~=3.10.2",
     "backoff~=2.2.1",
+    "click>=8.2.0",
     "GitPython>=3.0.0",
     "netaddr~=1.3.0",
     "numpy>=2.0.1,<3.0.0",


### PR DESCRIPTION
Even though typer 0.16 removes the need for mixstderr, it does not specify that this only exists in Click 8.2+. Thus we need to specify click 8.2+ to avoid any issues.