### PR TITLE
Better error formatting

### DIFF
--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -575,7 +575,9 @@ def format_error_message(error_message: Union[dict, Exception]) -> str:
             err_type = error_message.get("type", err_type)
             err_name = error_message.get("name", err_name)
             err_docs = error_message.get("docs", [err_description])
-            err_description = " ".join(err_docs)
+            err_description = (
+                " ".join(err_docs) if not isinstance(err_docs, str) else err_docs
+            )
             err_description += (
                 f" | Please consult {BT_DOCS_LINK}/errors/subtensor#{err_name.lower()}"
             )


### PR DESCRIPTION
<img width="3024" height="652" alt="Screenshot 2025-08-07 at 23 41 53" src="https://github.com/user-attachments/assets/f54518f7-e665-4e4c-bd9e-ff1225a55063" />

Only `" ".join` when err_docs are not a string.