### PR TITLE
disk cache in config

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1110,15 +1110,21 @@ class CLIManager:
                             f"[{COLORS.G.ARG}]{', '.join(not_selected_networks)}[/{COLORS.G.ARG}]"
                         )
 
-                    self.subtensor = SubtensorInterface(network_, use_disk_cache=use_disk_cache)
+                    self.subtensor = SubtensorInterface(
+                        network_, use_disk_cache=use_disk_cache
+                    )
                 elif self.config["network"]:
                     console.print(
                         f"Using the specified network [{COLORS.G.LINKS}]{self.config['network']}"
                         f"[/{COLORS.G.LINKS}] from config"
                     )
-                    self.subtensor = SubtensorInterface(self.config["network"], use_disk_cache=use_disk_cache)
+                    self.subtensor = SubtensorInterface(
+                        self.config["network"], use_disk_cache=use_disk_cache
+                    )
                 else:
-                    self.subtensor = SubtensorInterface(defaults.subtensor.network, use_disk_cache=use_disk_cache)
+                    self.subtensor = SubtensorInterface(
+                        defaults.subtensor.network, use_disk_cache=use_disk_cache
+                    )
         return self.subtensor
 
     def _run_command(self, cmd: Coroutine, exit_early: bool = True):
@@ -1280,7 +1286,7 @@ class CLIManager:
             "--disk-cache/--no-disk-cache",
             " /--no-disk-cache",
             help="Enables or disables the caching on disk. Enabling this can significantly speed up commands run "
-                 "sequentially"
+            "sequentially",
         ),
         rate_tolerance: Optional[float] = typer.Option(
             None,

--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -94,6 +94,7 @@ class Defaults:
             "wallet_name": None,
             "wallet_hotkey": None,
             "use_cache": True,
+            "disk_cache": False,
             "metagraph_cols": {
                 "UID": True,
                 "GLOBAL_STAKE": True,

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -42,12 +42,6 @@ from bittensor_cli.src.bittensor.utils import (
     get_hotkey_pub_ss58,
 )
 
-SubstrateClass = (
-    DiskCachedAsyncSubstrateInterface
-    if os.getenv("DISK_CACHE", "0") == "1"
-    else AsyncSubstrateInterface
-)
-
 
 class ParamWithTypes(TypedDict):
     name: str  # Name of the parameter.
@@ -81,7 +75,7 @@ class SubtensorInterface:
     Thin layer for interacting with Substrate Interface. Mostly a collection of frequently-used calls.
     """
 
-    def __init__(self, network):
+    def __init__(self, network, use_disk_cache: bool = False):
         if network in Constants.network_map:
             self.chain_endpoint = Constants.network_map[network]
             self.network = network
@@ -111,8 +105,12 @@ class SubtensorInterface:
                 )
                 self.chain_endpoint = Constants.network_map[defaults.subtensor.network]
                 self.network = defaults.subtensor.network
-
-        self.substrate = SubstrateClass(
+        substrate_class = (
+            DiskCachedAsyncSubstrateInterface
+            if (use_disk_cache or os.getenv("DISK_CACHE", "0") == "1")
+            else AsyncSubstrateInterface
+        )
+        self.substrate = substrate_class(
             url=self.chain_endpoint,
             ss58_format=SS58_FORMAT,
             type_registry=TYPE_REGISTRY,

--- a/bittensor_cli/src/commands/subnets/price.py
+++ b/bittensor_cli/src/commands/subnets/price.py
@@ -52,7 +52,17 @@ async def price(
 
             step = 300
             start_block = max(0, current_block - total_blocks)
-            block_numbers = list(range(start_block, current_block + 1, step))
+
+            # snap start block down to nearest multiple of 10
+            start_block -= start_block % 10
+
+            block_numbers = []
+            for b in range(start_block, current_block + 1, step):
+                if b == current_block:
+                    block_numbers.append(b)  # exact current block
+                else:
+                    block_numbers.append(b - (b % 5))  # snap down to multiple of 10
+            block_numbers = sorted(set(block_numbers))
 
             # Block hashes
             block_hash_cors = [


### PR DESCRIPTION
Instead of only allowing setting disk-cache in the env var, this also allows by setting in the config, which should be the preferred way.  It will pair nicely with the disk cache improvements in https://github.com/opentensor/async-substrate-interface/pull/176. Additionally, optimises `btcli s list` to get the most benefit of disk caching by using blocks that are multiples of 10.