### PR TITLE
Unstake no prompts

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3860,7 +3860,8 @@ class CLIManager:
                     default=self.config.get("wallet_name") or defaults.wallet.name,
                 )
             hotkey_or_ss58 = Prompt.ask(
-                "Enter the [blue]hotkey[/blue] name or [blue]ss58 address[/blue] to unstake from [dim](or Press Enter to view existing staked hotkeys)[/dim]",
+                "Enter the [blue]hotkey[/blue] name or [blue]ss58 address[/blue] to unstake from [dim]"
+                "(or Press Enter to view existing staked hotkeys)[/dim]",
             )
             if hotkey_or_ss58 == "":
                 wallet = self.wallet_ask(
@@ -3907,7 +3908,8 @@ class CLIManager:
             else:
                 if not hotkey_ss58_address and not wallet_hotkey:
                     hotkey_or_ss58 = Prompt.ask(
-                        "Enter the [blue]hotkey[/blue] name or [blue]ss58 address[/blue] to unstake all from [dim](or enter 'all' to unstake from all hotkeys)[/dim]",
+                        "Enter the [blue]hotkey[/blue] name or [blue]ss58 address[/blue] to unstake all from [dim]"
+                        "(or enter 'all' to unstake from all hotkeys)[/dim]",
                         default=self.config.get("wallet_hotkey")
                         or defaults.wallet.hotkey,
                     )

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3977,8 +3977,8 @@ class CLIManager:
             )
         if not amount and not prompt:
             print_error(
-                f"Just using [{COLORS.G.ARG}]--no-prompt[/{COLORS.G.ARG}] is too ambiguous. You need to specify an amount,"
-                f"or use "
+                f"Using [{COLORS.G.ARG}]--no-prompt[/{COLORS.G.ARG}] without an amount/all is too ambiguous. "
+                f"You need to specify an [{COLORS.G.ARG}]--amount[/{COLORS.G.ARG}] or use "
                 f"[{COLORS.G.ARG}]--unstake-all[/{COLORS.G.ARG}]/[{COLORS.G.ARG}]--unstake-all-alpha[/{COLORS.G.ARG}]."
             )
             return False
@@ -3987,8 +3987,8 @@ class CLIManager:
             json_console.print_json(
                 data={
                     "success": False,
-                    "err_msg": "Just using '--no-prompt' is too ambiguous without specifying an amount or "
-                    "'--unstake-all'/'--unstake-all-alpha'",
+                    "err_msg": "Using '--json-output' without an amount/all is too ambiguous. You need to specify an "
+                    "'--amount' or use '--unstake-all'/'--unstake-all-alpha'",
                 }
             )
             return False

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -12,7 +12,7 @@ import traceback
 import warnings
 from dataclasses import fields
 from pathlib import Path
-from typing import Coroutine, Optional, Union
+from typing import Coroutine, Optional, Union, Literal
 
 import numpy as np
 import rich
@@ -1671,7 +1671,7 @@ class CLIManager:
         wallet_name: Optional[str],
         wallet_path: Optional[str],
         wallet_hotkey: Optional[str],
-        ask_for: Optional[list[str]] = None,
+        ask_for: Optional[list[Union[str, Literal]]] = None,
         validate: WV = WV.WALLET,
         return_wallet_and_hotkey: bool = False,
     ) -> Union[Wallet, tuple[Wallet, str]]:

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3987,7 +3987,7 @@ class CLIManager:
             json_console.print_json(
                 data={
                     "success": False,
-                    "err_msg": "Too amibuous to use '--no-prompt' without specifying and amount or "
+                    "err_msg": "Just using '--no-prompt' is too ambiguous without specifying an amount or "
                     "'--unstake-all'/'--unstake-all-alpha'",
                 }
             )

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3798,11 +3798,11 @@ class CLIManager:
                 "Interactive mode cannot be used with hotkey selection options like "
                 "--include-hotkeys, --exclude-hotkeys, --all-hotkeys, or --hotkey."
             )
-            raise typer.Exit()
+            return False
 
         if unstake_all and unstake_all_alpha:
             print_error("Cannot specify both unstake-all and unstake-all-alpha.")
-            raise typer.Exit()
+            return False
 
         if not interactive and not unstake_all and not unstake_all_alpha:
             netuid = get_optional_netuid(netuid, all_netuids)
@@ -3811,19 +3811,19 @@ class CLIManager:
                     "You have specified hotkeys to include and also the `--all-hotkeys` flag. The flag"
                     " should only be used standalone (to use all hotkeys) or with `--exclude-hotkeys`."
                 )
-                raise typer.Exit()
+                return False
 
             if include_hotkeys and exclude_hotkeys:
                 print_error(
                     "You have specified both including and excluding hotkeys options. Select one or the other."
                 )
-                raise typer.Exit()
+                return False
 
             if unstake_all and amount:
                 print_error(
                     "Cannot specify both a specific amount and 'unstake-all'. Choose one or the other."
                 )
-                raise typer.Exit()
+                return False
 
             if amount and amount <= 0:
                 print_error(f"You entered an incorrect unstake amount: {amount}")
@@ -3891,12 +3891,12 @@ class CLIManager:
             if include_hotkeys:
                 if len(include_hotkeys) > 1:
                     print_error("Cannot unstake_all from multiple hotkeys at once.")
-                    raise typer.Exit()
+                    return False
                 elif is_valid_ss58_address(include_hotkeys[0]):
                     hotkey_ss58_address = include_hotkeys[0]
                 else:
                     print_error("Invalid hotkey ss58 address.")
-                    raise typer.Exit()
+                    return False
             elif all_hotkeys:
                 wallet = self.wallet_ask(
                     wallet_name,
@@ -3981,6 +3981,7 @@ class CLIManager:
                 "Hotkeys must be a comma-separated list of ss58s or names, e.g., `--include-hotkeys hk1,hk2`.",
                 is_ss58=False,
             )
+            return False
 
         if exclude_hotkeys:
             exclude_hotkeys = parse_to_list(
@@ -3989,6 +3990,7 @@ class CLIManager:
                 "Hotkeys must be a comma-separated list of ss58s or names, e.g., `--exclude-hotkeys hk3,hk4`.",
                 is_ss58=False,
             )
+            return False
 
         return self._run_command(
             remove_stake.unstake(

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3977,7 +3977,7 @@ class CLIManager:
             )
         if not amount and not prompt:
             print_error(
-                f"Too ambiguous to use [{COLORS.G.ARG}]--no-prompt[/{COLORS.G.ARG}]. You need to specify an amount,"
+                f"Just using [{COLORS.G.ARG}]--no-prompt[/{COLORS.G.ARG}] is too ambiguous. You need to specify an amount,"
                 f"or use "
                 f"[{COLORS.G.ARG}]--unstake-all[/{COLORS.G.ARG}]/[{COLORS.G.ARG}]--unstake-all-alpha[/{COLORS.G.ARG}]."
             )

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1671,9 +1671,7 @@ class CLIManager:
         wallet_name: Optional[str],
         wallet_path: Optional[str],
         wallet_hotkey: Optional[str],
-        ask_for: Optional[
-            list[Union[str, Literal[WO.NAME, WO.PATH, WO.HOTKEY]]]
-        ] = None,
+        ask_for: Optional[list[Literal[WO.NAME, WO.PATH, WO.HOTKEY]]] = None,
         validate: WV = WV.WALLET,
         return_wallet_and_hotkey: bool = False,
     ) -> Union[Wallet, tuple[Wallet, str]]:

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3977,9 +3977,9 @@ class CLIManager:
             )
         if not amount and not prompt:
             print_error(
-                f"Using [{COLORS.G.ARG}]--no-prompt[/{COLORS.G.ARG}] without an amount/'all' is too ambiguous. "
-                f"You need to specify an [{COLORS.G.ARG}]--amount[/{COLORS.G.ARG}] or use "
-                f"[{COLORS.G.ARG}]--unstake-all[/{COLORS.G.ARG}]/[{COLORS.G.ARG}]--unstake-all-alpha[/{COLORS.G.ARG}]."
+                f"Ambiguous request! Specify [{COLORS.G.ARG}]--amount[/{COLORS.G.ARG}], "
+                f"[{COLORS.G.ARG}]--all[/{COLORS.G.ARG}], "
+                f"or [{COLORS.G.ARG}]--all-alpha[/{COLORS.G.ARG}] to use [{COLORS.G.ARG}]--no-prompt[/{COLORS.G.ARG}]"
             )
             return False
 
@@ -3987,8 +3987,8 @@ class CLIManager:
             json_console.print_json(
                 data={
                     "success": False,
-                    "err_msg": "Using '--json-output' without an amount/'all' is too ambiguous. You need to specify an "
-                    "'--amount' or use '--unstake-all'/'--unstake-all-alpha'",
+                    "err_msg": "Ambiguous request! Specify '--amount', '--all', "
+                    "or '--all-alpha' to use '--json-output'",
                 }
             )
             return False

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3977,7 +3977,7 @@ class CLIManager:
             )
         if not amount and not prompt:
             print_error(
-                f"Using [{COLORS.G.ARG}]--no-prompt[/{COLORS.G.ARG}] without an amount/all is too ambiguous. "
+                f"Using [{COLORS.G.ARG}]--no-prompt[/{COLORS.G.ARG}] without an amount/'all' is too ambiguous. "
                 f"You need to specify an [{COLORS.G.ARG}]--amount[/{COLORS.G.ARG}] or use "
                 f"[{COLORS.G.ARG}]--unstake-all[/{COLORS.G.ARG}]/[{COLORS.G.ARG}]--unstake-all-alpha[/{COLORS.G.ARG}]."
             )
@@ -3987,7 +3987,7 @@ class CLIManager:
             json_console.print_json(
                 data={
                     "success": False,
-                    "err_msg": "Using '--json-output' without an amount/all is too ambiguous. You need to specify an "
+                    "err_msg": "Using '--json-output' without an amount/'all' is too ambiguous. You need to specify an "
                     "'--amount' or use '--unstake-all'/'--unstake-all-alpha'",
                 }
             )

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1671,7 +1671,9 @@ class CLIManager:
         wallet_name: Optional[str],
         wallet_path: Optional[str],
         wallet_hotkey: Optional[str],
-        ask_for: Optional[list[Union[str, Literal]]] = None,
+        ask_for: Optional[
+            list[Union[str, Literal[WO.NAME, WO.PATH, WO.HOTKEY]]]
+        ] = None,
         validate: WV = WV.WALLET,
         return_wallet_and_hotkey: bool = False,
     ) -> Union[Wallet, tuple[Wallet, str]]:

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3827,7 +3827,23 @@ class CLIManager:
 
             if amount and amount <= 0:
                 print_error(f"You entered an incorrect unstake amount: {amount}")
-                raise typer.Exit()
+                return False
+
+        if include_hotkeys:
+            include_hotkeys = parse_to_list(
+                include_hotkeys,
+                str,
+                "Hotkeys must be a comma-separated list of ss58s or names, e.g., `--include-hotkeys hk1,hk2`.",
+                is_ss58=False,
+            )
+
+        if exclude_hotkeys:
+            exclude_hotkeys = parse_to_list(
+                exclude_hotkeys,
+                str,
+                "Hotkeys must be a comma-separated list of ss58s or names, e.g., `--exclude-hotkeys hk3,hk4`.",
+                is_ss58=False,
+            )
 
         if (
             not wallet_hotkey

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3975,22 +3975,21 @@ class CLIManager:
                 ask_for=[WO.NAME, WO.PATH, WO.HOTKEY],
                 validate=WV.WALLET_AND_HOTKEY,
             )
-
-        if include_hotkeys:
-            include_hotkeys = parse_to_list(
-                include_hotkeys,
-                str,
-                "Hotkeys must be a comma-separated list of ss58s or names, e.g., `--include-hotkeys hk1,hk2`.",
-                is_ss58=False,
+        if not amount and not prompt:
+            print_error(
+                f"Too ambiguous to use [{COLORS.G.ARG}]--no-prompt[/{COLORS.G.ARG}]. You need to specify an amount,"
+                f"or use "
+                f"[{COLORS.G.ARG}]--unstake-all[/{COLORS.G.ARG}]/[{COLORS.G.ARG}]--unstake-all-alpha[/{COLORS.G.ARG}]."
             )
             return False
 
-        if exclude_hotkeys:
-            exclude_hotkeys = parse_to_list(
-                exclude_hotkeys,
-                str,
-                "Hotkeys must be a comma-separated list of ss58s or names, e.g., `--exclude-hotkeys hk3,hk4`.",
-                is_ss58=False,
+        if not amount and json_output:
+            json_console.print_json(
+                data={
+                    "success": False,
+                    "err_msg": "Too amibuous to use '--no-prompt' without specifying and amount or "
+                    "'--unstake-all'/'--unstake-all-alpha'",
+                }
             )
             return False
 


### PR DESCRIPTION
Initial investigation into #589 revealed we are handling `--no-prompt` correctly, but in the specific command being used, the amount was ambiguous, meaning we would have to query the user for it. This adds an error message informing the user to supply an amount, unstake-all, and/or unstake-all-alpha.

Additionally, does some code cleanup.