### PR TITLE
New cmd: `btcli utils latency`

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -6354,11 +6354,13 @@ class CLIManager:
         additional_networks = additional_networks or []
         if any(not x.startswith("ws") for x in additional_networks):
             err_console.print(
-                "Invalid network endpoint. Ensure you are specifying a valid websocket endpoint.",
+                "Invalid network endpoint. Ensure you are specifying a valid websocket endpoint"
+                f" (starting with [{COLORS.G.LINKS}]ws://[/{COLORS.G.LINKS}] or "
+                f"[{COLORS.G.LINKS}]wss://[/{COLORS.G.LINKS}]).",
             )
             return False
         results: dict[str, list[float]] = self._run_command(
-            best_connection(Constants.finney_nodes + (additional_networks or []))
+            best_connection(Constants.lite_nodes + additional_networks)
         )
         sorted_results = {
             k: v for k, v in sorted(results.items(), key=lambda item: item[1][0])

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -770,7 +770,7 @@ class CLIManager:
 
         # utils app
         self.app.add_typer(
-            self.utils_app, name="utils", no_args_is_help=True, hidden=True
+            self.utils_app, name="utils", no_args_is_help=True, hidden=False
         )
 
         # view app

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -622,7 +622,7 @@ class CLIManager:
     wallet_app: typer.Typer
     subnets_app: typer.Typer
     weights_app: typer.Typer
-    utils_app = typer.Typer(epilog=_epilog)
+    utils_app: typer.Typer
     view_app: typer.Typer
     asyncio_runner = asyncio
 
@@ -695,6 +695,7 @@ class CLIManager:
         self.weights_app = typer.Typer(epilog=_epilog)
         self.view_app = typer.Typer(epilog=_epilog)
         self.liquidity_app = typer.Typer(epilog=_epilog)
+        self.utils_app = typer.Typer(epilog=_epilog)
 
         # config alias
         self.app.add_typer(
@@ -1052,6 +1053,7 @@ class CLIManager:
         )(self.liquidity_remove)
 
         # utils app
+        self.utils_app.command("convert")(self.convert)
         self.utils_app.command("latency")(self.best_connection)
 
     def generate_command_tree(self) -> Tree:
@@ -6302,7 +6304,6 @@ class CLIManager:
         )
 
     @staticmethod
-    @utils_app.command("convert")
     def convert(
         from_rao: Optional[str] = typer.Option(
             None, "--rao", help="Convert amount from Rao"
@@ -6340,8 +6341,8 @@ class CLIManager:
             help="Network(s) to test for the best connection",
         ),
     ):
-        f"""
-        This command will give you the latency of all finney-like network in additional to any additional networks you specify via the {arg__("--network")} flag
+        """
+        This command will give you the latency of all finney-like network in additional to any additional networks you specify via the '--network' flag
         
         The results are three-fold. One column is the overall time to initialise a connection, send the requests, and wait for the results. The second column measures single ping-pong speed once connected. The third makes a real world call to fetch the chain head.
         

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -6343,7 +6343,7 @@ class CLIManager:
         f"""
         This command will give you the latency of all finney-like network in additional to any additional networks you specify via the {arg__("--network")} flag
         
-        The results are two-fold. One column is the overall time to initialise a connection, send a request, and wait for the result. The second column measures single ping-pong speed once connected.
+        The results are three-fold. One column is the overall time to initialise a connection, send the requests, and wait for the results. The second column measures single ping-pong speed once connected. The third makes a real world call to fetch the chain head.
         
         EXAMPLE
         
@@ -6366,11 +6366,18 @@ class CLIManager:
             Column("Network"),
             Column("End to End Latency", style="cyan"),
             Column("Single Request Ping", style="cyan"),
+            Column("Chain Head Request Latency", style="cyan"),
             title="Connection Latencies (seconds)",
             caption="lower value is faster",
         )
-        for n_name, (overall_latency, single_request) in sorted_results.items():
-            table.add_row(n_name, str(overall_latency), str(single_request))
+        for n_name, (
+            overall_latency,
+            single_request,
+            chain_head,
+        ) in sorted_results.items():
+            table.add_row(
+                n_name, str(overall_latency), str(single_request), str(chain_head)
+            )
         console.print(table)
         fastest = next(iter(sorted_results.keys()))
         if conf_net := self.config.get("network", ""):

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -6343,11 +6343,11 @@ class CLIManager:
     ):
         """
         This command will give you the latency of all finney-like network in additional to any additional networks you specify via the '--network' flag
-        
+
         The results are three-fold. One column is the overall time to initialise a connection, send the requests, and wait for the results. The second column measures single ping-pong speed once connected. The third makes a real world call to fetch the chain head.
-        
+
         EXAMPLE
-        
+
         [green]$[/green] btcli utils latency --network ws://189.234.12.45 --network wss://mysubtensor.duckdns.org
 
         """

--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -23,7 +23,7 @@ class Constants:
     dev_entrypoint = "wss://dev.chain.opentensor.ai:443"
     local_entrypoint = "ws://127.0.0.1:9944"
     latent_lite_entrypoint = "wss://lite.sub.latent.to:443"
-    finney_nodes = [finney_entrypoint, subvortex_entrypoint, latent_lite_entrypoint]
+    lite_nodes = [finney_entrypoint, subvortex_entrypoint, latent_lite_entrypoint]
     network_map = {
         "finney": finney_entrypoint,
         "test": finney_test_entrypoint,

--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -23,6 +23,7 @@ class Constants:
     dev_entrypoint = "wss://dev.chain.opentensor.ai:443"
     local_entrypoint = "ws://127.0.0.1:9944"
     latent_lite_entrypoint = "wss://lite.sub.latent.to:443"
+    finney_nodes = [finney_entrypoint, subvortex_entrypoint, latent_lite_entrypoint]
     network_map = {
         "finney": finney_entrypoint,
         "test": finney_test_entrypoint,

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -1669,15 +1669,18 @@ async def best_connection(networks: list[str]):
     """
     results = {}
     for network in networks:
-        t1 = time.monotonic()
-        async with websockets.connect(network) as websocket:
-            pong = await websocket.ping()
-            latency = await pong
-            pt1 = time.monotonic()
-            await websocket.send(
-                "{'jsonrpc': '2.0', 'method': 'chain_getHead', 'params': [], 'id': '82'}"
-            )
-            await websocket.recv()
-            t2 = time.monotonic()
-        results[network] = [t2 - t1, latency, t2 - pt1]
+        try:
+            t1 = time.monotonic()
+            async with websockets.connect(network) as websocket:
+                pong = await websocket.ping()
+                latency = await pong
+                pt1 = time.monotonic()
+                await websocket.send(
+                    "{'jsonrpc': '2.0', 'method': 'chain_getHead', 'params': [], 'id': '82'}"
+                )
+                await websocket.recv()
+                t2 = time.monotonic()
+            results[network] = [t2 - t1, latency, t2 - pt1]
+        except Exception as e:
+            err_console.print(f"Error attempting network {network}: {e}")
     return results


### PR DESCRIPTION
Adds a command to compare latencies of given connections to help the user pick the fastest for their region.

<img width="6502" height="1404" alt="image" src="https://github.com/user-attachments/assets/478f0a08-f465-4861-8e69-41570c713d1c" />


Simple usage:
```
btcli utils latency
```
<img width="4421" height="1059" alt="image" src="https://github.com/user-attachments/assets/8950081d-9530-4c73-9957-a6887906b307" />


or with additional networks:
<img width="4797" height="1174" alt="image" src="https://github.com/user-attachments/assets/cc560925-bbe9-477a-ac49-79f274e5a5d8" />

Resolves #594
