### PR TITLE
Update example for show command

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -5247,7 +5247,7 @@ class CLIManager:
 
         EXAMPLE
 
-        [green]$[/green] btcli subnets list
+        [green]$[/green] btcli subnets show
         """
         self.verbosity_handler(quiet, verbose, json_output)
         subtensor = self.initialize_chain(network)


### PR DESCRIPTION
Another tiny fix.
`btcli s show --help` currently displays the example command as `btcli subnets list`, it now displays the correct command.