### PR TITLE
Update cli.py to remove double negative typo

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1726,7 +1726,7 @@ class CLIManager:
             valid = utils.is_valid_wallet(wallet)
             if not valid[0]:
                 utils.err_console.print(
-                    f"[red]Error: Wallet does not not exist. \n"
+                    f"[red]Error: Wallet does not exist. \n"
                     f"Please verify your wallet information: {wallet}[/red]"
                 )
                 raise typer.Exit()


### PR DESCRIPTION
Ran into this error in the CLI stating the wallet did not not exist.  Looked into if this is an intentional double negative.  My research points to "no" it's a typo.

Looking at the logic:
1. utils.is_valid_wallet(wallet) returns a tuple where the first element (valid[0]) indicates if the wallet exists
2. The condition if not valid[0]: triggers when the wallet does NOT exist
3. So the error message should indicate the wallet doesn't exist