### PR TITLE
subnet symbol set command

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -960,6 +960,9 @@ class CLIManager:
         self.subnets_app.command(
             "check-start", rich_help_panel=HELP_PANELS["SUBNETS"]["INFO"]
         )(self.subnets_check_start)
+        self.subnets_app.command(
+            "set-symbol", rich_help_panel=HELP_PANELS["SUBNETS"]["IDENTITY"]
+        )(self.subnets_set_symbol)
 
         # weights commands
         self.weights_app.command(
@@ -5791,6 +5794,35 @@ class CLIManager:
                 not self.config.get("use_cache", True),
                 self.config.get("metagraph_cols", {}),
             )
+        )
+
+    def subnets_set_symbol(
+        self,
+        wallet_name: str = Options.wallet_name,
+        wallet_path: str = Options.wallet_path,
+        wallet_hotkey: str = Options.wallet_hotkey,
+        network: Optional[list[str]] = Options.network,
+        netuid: int = Options.netuid,
+        json_output: bool = Options.json_output,
+        prompt: bool = Options.prompt,
+        quiet: bool = Options.quiet,
+        verbose: bool = Options.verbose,
+        symbol: str = typer.Argument(help="The symbol to set for your subnet."),
+    ):
+        """
+        Allows the user to update their subnet symbol.
+
+        EXAMPLE
+
+        [green]$[/green] btcli subnets set-symbol --netuid 1 ‡
+        """
+        self.verbosity_handler(quiet, verbose, json_output)
+        wallet = self.wallet_ask(
+            wallet_name,
+            wallet_path,
+            wallet_hotkey,
+            ask_for=[WO.NAME, WO.HOTKEY],
+            validate=WV.WALLET_AND_HOTKEY,
         )
 
     def weights_reveal(

--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -2448,3 +2448,66 @@ async def start_subnet(
             await get_start_schedule(subtensor, netuid)
             print_error(f":cross_mark: Failed to start subnet: {error_msg}")
             return False
+
+
+async def set_symbol(
+    wallet: "Wallet",
+    subtensor: "SubtensorInterface",
+    netuid: int,
+    symbol: str,
+    prompt: bool = False,
+    json_output: bool = False,
+) -> bool:
+    """Set a subtensor's symbol"""
+    if not await subtensor.subnet_exists(netuid):
+        err = f"Subnet {netuid} does not exist."
+        if json_output:
+            json_console.print_json(data={"success": False, "message": err})
+        else:
+            err_console.print(err)
+        return False
+
+    if prompt and not json_output:
+        sn_info = await subtensor.subnet(netuid=netuid)
+        if not Confirm.ask(
+            f"Your current subnet symbol for SN{netuid} is {sn_info.symbol}. Do you want to update it to {symbol}?"
+        ):
+            return False
+
+    if not (unlock_status := unlock_key(wallet, print_out=False)).success:
+        err = unlock_status.message
+        if json_output:
+            json_console.print_json(data={"success": False, "message": err})
+        else:
+            console.print(err)
+        return False
+
+    start_call = await subtensor.substrate.compose_call(
+        call_module="SubtensorModule",
+        call_function="update_symbol",
+        call_params={"netuid": netuid, "symbol": symbol},
+    )
+
+    signed_ext = await subtensor.substrate.create_signed_extrinsic(
+        call=start_call,
+        keypair=wallet.coldkey,
+    )
+
+    response = await subtensor.substrate.submit_extrinsic(
+        extrinsic=signed_ext,
+        wait_for_inclusion=True,
+    )
+    if await response.is_success:
+        message = f"Successfully updated SN{netuid}'s symbol to {symbol}."
+        if json_output:
+            json_console.print_json(data={"success": True, "message": message})
+        else:
+            console.print(f":white_heavy_check_mark:[dark_sea_green3] {message}\n")
+        return True
+    else:
+        err = format_error_message(await response.error_message)
+        if json_output:
+            json_console.print_json(data={"success": False, "message": err})
+        else:
+            err_console.print(f":cross_mark: [red]Failed[/red]: {err}")
+        return False

--- a/tests/e2e_tests/test_staking_sudo.py
+++ b/tests/e2e_tests/test_staking_sudo.py
@@ -10,6 +10,7 @@ Verify commands:
 * btcli subnets create
 * btcli subnets set-identity
 * btcli subnets get-identity
+* btcli subnets set-symbol
 * btcli subnets register
 * btcli subnets price
 * btcli stake add
@@ -234,6 +235,33 @@ def test_staking(local_chain, wallet_setup):
     assert get_identity_output["description"] == sn_description
     assert get_identity_output["logo_url"] == sn_logo_url
     assert get_identity_output["additional"] == sn_add_info
+
+    # set symbol
+    set_symbol = exec_command_alice(
+        "subnets",
+        "set-symbol",
+        extra_args=[
+            "--wallet-path",
+            wallet_path_alice,
+            "--wallet-name",
+            wallet_alice.name,
+            "--hotkey",
+            wallet_alice.hotkey_str,
+            "--chain",
+            "ws://127.0.0.1:9945",
+            "--netuid",
+            netuid,
+            "--json-output",
+            "--no-prompt",
+            "‡",
+        ],
+    )
+    set_symbol_output = json.loads(set_symbol.stdout)
+    assert set_symbol_output["success"] is True
+    assert (
+        set_symbol_output["message"]
+        == f"Successfully updated SN{netuid}'s symbol to ‡."
+    )
 
     get_s_price = exec_command_alice(
         "subnets",


### PR DESCRIPTION
Fixes #612 

Adds `btcli s set-symbol` command to allow users to set their subnet symbol.