### PR TITLE
Transfer not staking warning

### DIFF
--- a/bittensor_cli/src/bittensor/extrinsics/transfer.py
+++ b/bittensor_cli/src/bittensor/extrinsics/transfer.py
@@ -175,7 +175,9 @@ async def transfer_extrinsic(
             f"  amount: [bright_cyan]{amount if not transfer_all else account_balance}[/bright_cyan]\n"
             f"  from: [light_goldenrod2]{wallet.name}[/light_goldenrod2] : "
             f"[bright_magenta]{wallet.coldkey.ss58_address}\n[/bright_magenta]"
-            f"  to: [bright_magenta]{destination}[/bright_magenta]\n  for fee: [bright_cyan]{fee}[/bright_cyan]"
+            f"  to: [bright_magenta]{destination}[/bright_magenta]\n  for fee: [bright_cyan]{fee}[/bright_cyan]\n"
+            f":warning:[bright_yellow]Transferring is not the same as staking. To instead stake, use "
+            f"[dark_orange]btcli stake add[/dark_orange] instead[/bright_yellow]:warning:"
         ):
             return False
 


### PR DESCRIPTION
Adds a warning on transfers that transferring is not the same as staking.