### PR TITLE
Feat/auto staking

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3559,7 +3559,7 @@ class CLIManager:
                 )
 
         return self._run_command(
-            auto_stake.show_auto_destinations(
+            auto_stake.show_auto_stake_destinations(
                 wallet,
                 self.initialize_chain(network),
                 coldkey_ss58=coldkey_ss58,

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -72,6 +72,7 @@ from bittensor_cli.src.commands.liquidity.utils import (
     prompt_position_id,
 )
 from bittensor_cli.src.commands.stake import (
+    auto_staking as auto_stake,
     children_hotkeys,
     list as list_stake,
     move as move_stake,
@@ -905,6 +906,9 @@ class CLIManager:
         self.stake_app.command(
             "add", rich_help_panel=HELP_PANELS["STAKE"]["STAKE_MGMT"]
         )(self.stake_add)
+        self.stake_app.command(
+            "auto", rich_help_panel=HELP_PANELS["STAKE"]["STAKE_MGMT"]
+        )(self.get_auto_stake)
         self.stake_app.command(
             "remove", rich_help_panel=HELP_PANELS["STAKE"]["STAKE_MGMT"]
         )(self.stake_remove)
@@ -3502,6 +3506,62 @@ class CLIManager:
                 subtensor=self.initialize_chain(network),
                 new_coldkey_ss58=new_wallet_coldkey_ss58,
                 force_swap=force_swap,
+            )
+        )
+
+    def get_auto_stake(
+        self,
+        network: Optional[list[str]] = Options.network,
+        wallet_name: Optional[str] = Options.wallet_name,
+        wallet_path: Optional[str] = Options.wallet_path,
+        coldkey_ss58=typer.Option(
+            None,
+            "--ss58",
+            "--coldkey_ss58",
+            "--coldkey.ss58_address",
+            "--coldkey.ss58",
+            help="Coldkey address of the wallet",
+        ),
+        quiet: bool = Options.quiet,
+        verbose: bool = Options.verbose,
+        json_output: bool = Options.json_output,
+    ):
+        """Display auto-stake destinations for a wallet across all subnets."""
+
+        self.verbosity_handler(quiet, verbose, json_output)
+
+        wallet = None
+        if coldkey_ss58:
+            if not is_valid_ss58_address(coldkey_ss58):
+                print_error("You entered an invalid ss58 address")
+                raise typer.Exit()
+        else:
+            if wallet_name:
+                coldkey_or_ss58 = wallet_name
+            else:
+                coldkey_or_ss58 = Prompt.ask(
+                    "Enter the [blue]wallet name[/blue] or [blue]coldkey ss58 address[/blue]",
+                    default=self.config.get("wallet_name") or defaults.wallet.name,
+                )
+            if is_valid_ss58_address(coldkey_or_ss58):
+                coldkey_ss58 = coldkey_or_ss58
+            else:
+                wallet_name = coldkey_or_ss58 if coldkey_or_ss58 else wallet_name
+                wallet = self.wallet_ask(
+                    wallet_name,
+                    wallet_path,
+                    None,
+                    ask_for=[WO.NAME, WO.PATH],
+                    validate=WV.WALLET,
+                )
+
+        return self._run_command(
+            auto_stake.show_auto_destinations(
+                wallet,
+                self.initialize_chain(network),
+                coldkey_ss58=coldkey_ss58,
+                json_output=json_output,
+                verbose=verbose,
             )
         )
 

--- a/bittensor_cli/src/commands/stake/auto_staking.py
+++ b/bittensor_cli/src/commands/stake/auto_staking.py
@@ -22,7 +22,7 @@ if TYPE_CHECKING:
     from bittensor_cli.src.bittensor.subtensor_interface import SubtensorInterface
 
 
-async def show_auto_destinations(
+async def show_auto_stake_destinations(
     wallet: Optional[Wallet],
     subtensor: "SubtensorInterface",
     coldkey_ss58: Optional[str] = None,

--- a/bittensor_cli/src/commands/stake/auto_staking.py
+++ b/bittensor_cli/src/commands/stake/auto_staking.py
@@ -1,0 +1,169 @@
+import asyncio
+import json
+from typing import Optional, TYPE_CHECKING
+
+from bittensor_wallet import Wallet
+from rich import box
+from rich.table import Table
+from rich.prompt import Confirm
+
+from bittensor_cli.src import COLOR_PALETTE
+from bittensor_cli.src.bittensor.utils import (
+    console,
+    json_console,
+    get_subnet_name,
+    is_valid_ss58_address,
+    print_error,
+    err_console,
+    unlock_key,
+)
+
+if TYPE_CHECKING:
+    from bittensor_cli.src.bittensor.subtensor_interface import SubtensorInterface
+
+
+async def show_auto_destinations(
+    wallet: Optional[Wallet],
+    subtensor: "SubtensorInterface",
+    coldkey_ss58: Optional[str] = None,
+    json_output: bool = False,
+    verbose: bool = False,
+) -> Optional[dict[int, dict[str, Optional[str]]]]:
+    """Display auto-stake destinations for the supplied wallet."""
+
+    wallet_name: Optional[str] = wallet.name if wallet else None
+    coldkey_ss58 = coldkey_ss58 or (wallet.coldkeypub.ss58_address if wallet else None)
+    if not coldkey_ss58:
+        raise ValueError("A wallet or coldkey SS58 address must be provided")
+
+    with console.status(
+        f"Retrieving auto-stake configuration from {subtensor.network}...",
+        spinner="earth",
+    ):
+        chain_head = await subtensor.substrate.get_chain_head()
+        (
+            subnet_info,
+            auto_destinations,
+            identities,
+            delegate_identities,
+        ) = await asyncio.gather(
+            subtensor.all_subnets(block_hash=chain_head),
+            subtensor.get_auto_stake_destinations(
+                coldkey_ss58=coldkey_ss58,
+                block_hash=chain_head,
+                reuse_block=True,
+            ),
+            subtensor.fetch_coldkey_hotkey_identities(block_hash=chain_head),
+            subtensor.get_delegate_identities(block_hash=chain_head),
+        )
+
+    subnet_map = {info.netuid: info for info in subnet_info}
+    auto_destinations = auto_destinations or {}
+    identities = identities or {}
+    delegate_identities = delegate_identities or {}
+    hotkey_identities = identities.get("hotkeys", {})
+
+    def resolve_identity(hotkey: str) -> Optional[str]:
+        if not hotkey:
+            return None
+
+        identity_entry = hotkey_identities.get(hotkey, {}).get("identity")
+        if identity_entry:
+            display_name = identity_entry.get("name") or identity_entry.get("display")
+            if display_name:
+                return display_name
+
+        delegate_info = delegate_identities.get(hotkey)
+        if delegate_info and getattr(delegate_info, "display", ""):
+            return delegate_info.display
+
+        return None
+
+    coldkey_display = wallet_name
+    if not coldkey_display:
+        coldkey_identity = identities.get("coldkeys", {}).get(coldkey_ss58, {})
+        if identity_data := coldkey_identity.get("identity"):
+            coldkey_display = identity_data.get("name") or identity_data.get("display")
+        if not coldkey_display:
+            coldkey_display = f"{coldkey_ss58[:6]}...{coldkey_ss58[-6:]}"
+
+    rows = []
+    data_output: dict[int, dict[str, Optional[str]]] = {}
+
+    for netuid in sorted(subnet_map):
+        subnet = subnet_map[netuid]
+        subnet_name = get_subnet_name(subnet)
+        hotkey_ss58 = auto_destinations.get(netuid)
+        identity_str = resolve_identity(hotkey_ss58) if hotkey_ss58 else None
+        is_custom = hotkey_ss58 is not None
+
+        data_output[netuid] = {
+            "subnet_name": subnet_name,
+            "status": "custom" if is_custom else "default",
+            "destination": hotkey_ss58,
+            "identity": identity_str,
+        }
+
+        if json_output:
+            continue
+
+        status_text = (
+            f"[{COLOR_PALETTE['STAKE']['STAKE_ALPHA']}]Custom[/{COLOR_PALETTE['STAKE']['STAKE_ALPHA']}]"
+            if is_custom
+            else f"[{COLOR_PALETTE['GENERAL']['HINT']}]Default[/{COLOR_PALETTE['GENERAL']['HINT']}]"
+        )
+
+        rows.append(
+            (
+                str(netuid),
+                subnet_name,
+                status_text,
+                hotkey_ss58,
+                identity_str or "",
+            )
+        )
+
+    if json_output:
+        json_console.print(json.dumps(data_output))
+        return data_output
+
+    table = Table(
+        title=(
+            f"\n[{COLOR_PALETTE['GENERAL']['HEADER']}]Auto Stake Destinations"
+            f" for [bold]{coldkey_display}[/bold]\n"
+            f"Network: {subtensor.network}\n"
+            f"Coldkey: {coldkey_ss58}\n"
+            f"[/{COLOR_PALETTE['GENERAL']['HEADER']}]"
+        ),
+        show_edge=False,
+        header_style="bold white",
+        border_style="bright_black",
+        style="bold",
+        title_justify="center",
+        show_lines=False,
+        pad_edge=True,
+        box=box.SIMPLE_HEAD,
+    )
+
+    table.add_column(
+        "Netuid", style=COLOR_PALETTE["GENERAL"]["SYMBOL"], justify="center"
+    )
+    table.add_column("Subnet", style="cyan", justify="left")
+    table.add_column("Status", style="white", justify="center")
+    table.add_column(
+        "Destination Hotkey", style=COLOR_PALETTE["GENERAL"]["HOTKEY"], justify="center"
+    )
+    table.add_column(
+        "Identity", style=COLOR_PALETTE["GENERAL"]["SUBHEADING"], justify="left"
+    )
+
+    for row in rows:
+        table.add_row(*row)
+
+    console.print(table)
+    console.print(
+        f"\n[{COLOR_PALETTE['GENERAL']['SUBHEADING']}]Total subnets:[/] {len(subnet_map)}  "
+        f"[{COLOR_PALETTE['GENERAL']['SUBHEADING']}]Custom destinations:[/] {len(auto_destinations)}"
+    )
+
+    return None

--- a/bittensor_cli/src/commands/stake/auto_staking.py
+++ b/bittensor_cli/src/commands/stake/auto_staking.py
@@ -16,6 +16,7 @@ from bittensor_cli.src.bittensor.utils import (
     print_error,
     err_console,
     unlock_key,
+    print_extrinsic_id,
 )
 
 if TYPE_CHECKING:
@@ -264,12 +265,14 @@ async def set_auto_stake_destination(
         f":satellite: Setting auto-stake destination on [white]{subtensor.network}[/white]...",
         spinner="earth",
     ):
-        success, error_message = await subtensor.sign_and_send_extrinsic(
+        success, error_message, ext_receipt = await subtensor.sign_and_send_extrinsic(
             call,
             wallet,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
         )
+
+    ext_id = await ext_receipt.get_extrinsic_identifier() if success else None
 
     if json_output:
         json_console.print(
@@ -279,11 +282,13 @@ async def set_auto_stake_destination(
                     "error": error_message,
                     "netuid": netuid,
                     "hotkey": hotkey_ss58,
+                    "extrinsic_identifier": ext_id,
                 }
             )
         )
 
     if success:
+        await print_extrinsic_id(ext_receipt)
         console.print(
             f":white_heavy_check_mark: [dark_sea_green3]Auto-stake destination set for netuid {netuid}[/dark_sea_green3]"
         )


### PR DESCRIPTION
## Auto-staking
### (Do not merge - awaiting subtensor to finalize)

### 1. `btcli stake auto`
> [!IMPORTANT]
> Similar to subnet list, but displays the target auto-staking hotkey 
> If it is set, the HK is displayed; otherwise default behaviour is mentioned. 
<img width="874" height="292" alt="image" src="https://github.com/user-attachments/assets/e9f11f33-5591-47ca-a3f0-2470847e1b72" />

### 2. `btcli stake set-auto`
> [!IMPORTANT]
> Allows users to set target hotkey for automatic staking, within a subnet. 
> Allows users to either enter the hotkey on their own or displays a list of top validators active on the subnet. 
> Identities are also shown beside the keys

<img width="1044" height="574" alt="image" src="https://github.com/user-attachments/assets/ae939431-80ce-4c90-99ed-6d5e1504aebd" />

> [!NOTE]
> To be extended to allow setting for multiple netuids