### PR TITLE
Removes warning icon in transfer

### DIFF
--- a/bittensor_cli/src/bittensor/extrinsics/transfer.py
+++ b/bittensor_cli/src/bittensor/extrinsics/transfer.py
@@ -176,8 +176,8 @@ async def transfer_extrinsic(
             f"  from: [light_goldenrod2]{wallet.name}[/light_goldenrod2] : "
             f"[bright_magenta]{wallet.coldkey.ss58_address}\n[/bright_magenta]"
             f"  to: [bright_magenta]{destination}[/bright_magenta]\n  for fee: [bright_cyan]{fee}[/bright_cyan]\n"
-            f":warning:[bright_yellow]Transferring is not the same as staking. To instead stake, use "
-            f"[dark_orange]btcli stake add[/dark_orange] instead[/bright_yellow]:warning:"
+            f"[bright_yellow]Transferring is not the same as staking. To instead stake, use "
+            f"[dark_orange]btcli stake add[/dark_orange] instead[/bright_yellow]"
         ):
             return False
 


### PR DESCRIPTION
<img width="834" height="40" alt="image" src="https://github.com/user-attachments/assets/b6db50bd-c343-4503-9d2d-206851dace78" />

The warning itself is legible but the icon does not render well. 