### PR TITLE
Feat/Individual wallet list

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1875,6 +1875,7 @@ class CLIManager:
 
     def wallet_list(
         self,
+        wallet_name: Optional[str] = Options.wallet_name,
         wallet_path: str = Options.wallet_path,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
@@ -1898,7 +1899,13 @@ class CLIManager:
         wallet = self.wallet_ask(
             None, wallet_path, None, ask_for=[WO.PATH], validate=WV.NONE
         )
-        return self._run_command(wallets.wallet_list(wallet.path, json_output))
+        return self._run_command(
+            wallets.wallet_list(
+                wallet.path,
+                json_output,
+                wallet_name=wallet_name,
+            )
+        )
 
     def wallet_overview(
         self,

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -813,12 +813,21 @@ async def wallet_history(wallet: Wallet):
     console.print(table)
 
 
-async def wallet_list(wallet_path: str, json_output: bool):
+async def wallet_list(
+    wallet_path: str, json_output: bool, wallet_name: Optional[str] = None
+):
     """Lists wallets."""
     wallets = utils.get_coldkey_wallets_for_path(wallet_path)
     print_verbose(f"Using wallets path: {wallet_path}")
     if not wallets:
         err_console.print(f"[red]No wallets found in dir: {wallet_path}[/red]")
+
+    if wallet_name:
+        wallets = [wallet for wallet in wallets if wallet.name == wallet_name]
+        if not wallets:
+            err_console.print(
+                f"[red]Wallet '{wallet_name}' not found in dir: {wallet_path}[/red]"
+            )
 
     root = Tree("Wallets")
     main_data_dict = {"wallets": []}
@@ -876,7 +885,12 @@ async def wallet_list(wallet_path: str, json_output: bool):
 
     if not wallets:
         print_verbose(f"No wallets found in path: {wallet_path}")
-        root.add("[bold red]No wallets found.")
+        message = (
+            "[bold red]No wallets found."
+            if not wallet_name
+            else f"[bold red]Wallet '{wallet_name}' not found."
+        )
+        root.add(message)
     if json_output:
         json_console.print(json.dumps(main_data_dict))
     else:


### PR DESCRIPTION
- `btcli wallet list --wallet-name alice` should now display the tree only for that specific wallet
- Helps list a specific wallet instead of listing all & then Ctrl + F
- Default behaviour is untouched
<img width="712" height="318" alt="image" src="https://github.com/user-attachments/assets/3be1f46b-cdbb-4659-b0af-84c1c7ce42d6" />
