### PR TITLE
commands list fixes

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1106,7 +1106,9 @@ class CLIManager:
             "get_identity",
             hidden=True,
         )(self.wallet_get_id)
-        self.wallet_app.command("associate_hotkey", hidden=True)(self.wallet_associate_hotkey)
+        self.wallet_app.command("associate_hotkey", hidden=True)(
+            self.wallet_associate_hotkey
+        )
 
         # Subnets
         self.subnets_app.command("burn_cost", hidden=True)(self.subnets_burn_cost)

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1106,7 +1106,7 @@ class CLIManager:
             "get_identity",
             hidden=True,
         )(self.wallet_get_id)
-        self.wallet_app.command("associate_hotkey")(self.wallet_associate_hotkey)
+        self.wallet_app.command("associate_hotkey", hidden=True)(self.wallet_associate_hotkey)
 
         # Subnets
         self.subnets_app.command("burn_cost", hidden=True)(self.subnets_burn_cost)

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -617,6 +617,7 @@ def commands_callback(value: bool):
     if value:
         cli = CLIManager()
         console.print(cli.generate_command_tree())
+    raise typer.Exit()
 
 
 def debug_callback(value: bool):

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -618,7 +618,7 @@ def commands_callback(value: bool):
     if value:
         cli = CLIManager()
         console.print(cli.generate_command_tree())
-    raise typer.Exit()
+        raise typer.Exit()
 
 
 def debug_callback(value: bool):


### PR DESCRIPTION
1. Hides the `associate_hotkey` alias
2. ensures no error at the end of `btcli --commands`