### PR TITLE
Childkey take was incorrectly labeled.

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -5229,7 +5229,7 @@ class CLIManager:
         network: Optional[list[str]] = Options.network,
         child_hotkey_ss58: Optional[str] = typer.Option(
             None,
-            "child-hotkey-ss58",
+            "--child-hotkey-ss58",
             help="The hotkey SS58 to designate as child (not specifying will use the provided wallet's hotkey)",
             prompt=False,
         ),
@@ -5306,7 +5306,7 @@ class CLIManager:
                 subtensor=self.initialize_chain(network),
                 netuid=netuid,
                 take=take,
-                hotkey=hotkey,
+                hotkey=child_hotkey_ss58,
                 wait_for_inclusion=wait_for_inclusion,
                 wait_for_finalization=wait_for_finalization,
                 prompt=prompt,


### PR DESCRIPTION
Before fix:
<img width="2924" height="1666" alt="image" src="https://github.com/user-attachments/assets/a6aa9b7f-5323-4c7d-aeef-4861b3f82bd0" />

After fix:
<img width="1649" height="892" alt="Screenshot 2025-10-22 at 16 09 38" src="https://github.com/user-attachments/assets/69a2dff4-1140-4cba-9f94-b09408c25ff1" />

Incorrectly named param.