### PR TITLE
Adds wallet balance sorting

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -39,6 +39,7 @@ from bittensor_cli.src import (
     Constants,
     COLORS,
     HYPERPARAMS,
+    WalletOptions,
 )
 from bittensor_cli.src.bittensor import utils
 from bittensor_cli.src.bittensor.balances import Balance
@@ -92,6 +93,7 @@ from bittensor_cli.src.commands.subnets import (
     subnets,
     mechanisms as subnet_mechanisms,
 )
+from bittensor_cli.src.commands.wallets import SortByBalance
 from bittensor_cli.version import __version__, __version_as_int__
 
 try:
@@ -1910,7 +1912,7 @@ class CLIManager:
         wallet_name: Optional[str],
         wallet_path: Optional[str],
         wallet_hotkey: Optional[str],
-        ask_for: Optional[list[Literal[WO.NAME, WO.PATH, WO.HOTKEY]]] = None,
+        ask_for: Optional[list[WalletOptions]] = None,
         validate: WV = WV.WALLET,
         return_wallet_and_hotkey: bool = False,
     ) -> Union[Wallet, tuple[Wallet, str]]:
@@ -3161,6 +3163,11 @@ class CLIManager:
             "-a",
             help="Whether to display the balances for all the wallets.",
         ),
+        sort_by: Optional[wallets.SortByBalance] = typer.Option(
+            None,
+            "--sort",
+            help="When using `--all`, sorts the wallets by a given column",
+        ),
         network: Optional[list[str]] = Options.network,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
@@ -3260,7 +3267,7 @@ class CLIManager:
         subtensor = self.initialize_chain(network)
         return self._run_command(
             wallets.wallet_balance(
-                wallet, subtensor, all_balances, ss58_addresses, json_output
+                wallet, subtensor, all_balances, ss58_addresses, sort_by, json_output
             )
         )
 


### PR DESCRIPTION
Adds `--sort` param to `wallet balance` to resolve #371

Allows sorting by wallet name, free balance, staked value, or total.

Not sorted:
<img width="3843" height="2038" alt="image" src="https://github.com/user-attachments/assets/d1b4a7f5-cc84-48e9-9d7d-5e45c12199d8" />

name:
<img width="3843" height="2038" alt="image" src="https://github.com/user-attachments/assets/571ab71c-34df-4b8c-be0b-68d78d5ad7da" />

free:
<img width="3843" height="2038" alt="image" src="https://github.com/user-attachments/assets/e0d5e3da-8987-452a-bde6-2b1a23998733" />

staked:
<img width="3843" height="2038" alt="image" src="https://github.com/user-attachments/assets/0ceeada2-f53e-415a-9cc6-5ed66d6f9074" />

total:
<img width="3843" height="2038" alt="image" src="https://github.com/user-attachments/assets/03b94ecb-b8b2-44dc-81b6-45c74a467306" />
