### PR TITLE
`stake remove --all` fails when unsuccessful

### DIFF
--- a/bittensor_cli/src/commands/stake/remove.py
+++ b/bittensor_cli/src/commands/stake/remove.py
@@ -547,7 +547,7 @@ async def unstake_all(
                 status=status,
                 era=era,
             )
-            ext_id = await ext_receipt.get_extrinsic_identifier() if successes else None
+            ext_id = await ext_receipt.get_extrinsic_identifier() if success else None
             successes[hotkey_ss58] = {
                 "success": success,
                 "extrinsic_identifier": ext_id,


### PR DESCRIPTION
Because we were checking `successes` which is a dict that gets updated in the loop, instead of `success` (the in-loop success), we would fail for an `AttributeError` if there were multiple hotkeys.