### PR TITLE
Update SDK link to use main branch instead of master

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 ## Internet-scale Neural Networks <!-- omit in toc -->
 
-[SDK](https://github.com/opentensor/bittensor/tree/master) • [Wallet](https://github.com/opentensor/btwallet) • [Research](https://bittensor.com/whitepaper)
+[SDK](https://github.com/opentensor/bittensor/tree/main) • [Wallet](https://github.com/opentensor/btwallet) • [Research](https://bittensor.com/whitepaper)
 
 </div>
 


### PR DESCRIPTION
Updated the Bittensor SDK repository link in README to point to the main branch instead of the deprecated master branch reference.

Fixes #646