### PR TITLE
Feat/delegated claim type

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -6046,7 +6046,7 @@ class CLIManager:
         [green]$[/green] btcli stake show-validator-claims --hotkey 5Grw...
         [green]$[/green] btcli stake show-validator-claims --wallet-name my_wallet --wallet-hotkey hk
         """
-        self.verbosity_handler(quiet, verbose, False, prompt)
+        self.verbosity_handler(quiet, verbose, json_output, False)
 
         if not hotkey_ss58 and not wallet_name:
             ss58_or_wallet = Prompt.ask(

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1091,6 +1091,9 @@ class CLIManager:
         self.stake_app.command(
             "show-validator-claims", rich_help_panel=HELP_PANELS["STAKE"]["CLAIM"]
         )(self.show_validator_claims)
+        self.stake_app.command(
+            "set-validator-claims", rich_help_panel=HELP_PANELS["STAKE"]["CLAIM"]
+        )(self.set_validator_claim_types)
 
         # stake-children commands
         children_app = typer.Typer()
@@ -5875,6 +5878,78 @@ class CLIManager:
                 netuids=netuids,
                 proxy=proxy,
                 prompt=prompt,
+                json_output=json_output,
+            )
+        )
+
+    def set_validator_claim_types(
+        self,
+        keep: Optional[str] = typer.Option(
+            None,
+            "--keep",
+            help="Subnets to keep emissions for (e.g. '1,3-5').",
+        ),
+        swap: Optional[str] = typer.Option(
+            None,
+            "--swap",
+            help="Subnets to swap emissions for (e.g. '2,6-10').",
+        ),
+        keep_all: bool = typer.Option(
+            False,
+            "--keep-all",
+            help="Set all registered subnets to Keep.",
+        ),
+        swap_all: bool = typer.Option(
+            False,
+            "--swap-all",
+            help="Set all registered subnets to Swap.",
+        ),
+        wallet_name: Optional[str] = Options.wallet_name,
+        wallet_path: Optional[str] = Options.wallet_path,
+        wallet_hotkey: Optional[str] = Options.wallet_hotkey,
+        network: Optional[list[str]] = Options.network,
+        proxy: Optional[str] = Options.proxy,
+        announce_only: bool = Options.announce_only,
+        prompt: bool = Options.prompt,
+        quiet: bool = Options.quiet,
+        verbose: bool = Options.verbose,
+        json_output: bool = Options.json_output,
+    ):
+        """
+        Set the claim type for a validator across multiple subnets.
+
+        This command allows validators to specify how they want to handle emissions for each subnet:
+        - [bold]Keep[/bold]: Keep emissions as Alpha tokens on the subnet.
+        - [bold]Swap[/bold]: Automatically swap Alpha emissions to TAO on the root network.
+
+        You can set preferences for specific subnets using [blue]--keep[/blue] and [blue]--swap[/blue], or update all registered subnets using [blue]--keep-all[/blue] or [blue]--swap-all[/blue].
+
+        If no arguments are provided, an interactive editor will be launched.
+
+        EXAMPLES:
+        [green]$[/green] btcli stake set-validator-claim --keep 1,3-5 --swap 2,10
+        [green]$[/green] btcli stake set-validator-claim --keep-all
+        [green]$[/green] btcli stake set-validator-claim (Interactive mode)
+        """
+        self.verbosity_handler(quiet, verbose, json_output, prompt)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
+        wallet = self.wallet_ask(
+            wallet_name,
+            wallet_path,
+            wallet_hotkey,
+            ask_for=[WO.NAME, WO.HOTKEY],
+            validate=WV.WALLET_AND_HOTKEY,
+        )
+        return self._run_command(
+            validator_claim.set_validator_claim_type(
+                wallet=wallet,
+                subtensor=self.initialize_chain(network),
+                keep=keep,
+                swap=swap,
+                keep_all=keep_all,
+                swap_all=swap_all,
+                prompt=prompt,
+                proxy=proxy,
                 json_output=json_output,
             )
         )

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -6044,7 +6044,9 @@ class CLIManager:
         """
         Show validator claim types (Keep/Swap) across all subnets for a validator hotkey.
 
-        Provide a hotkey SS58 directly, or supply a wallet and hotkey name to resolve it.
+        EXAMPLES:
+        [green]$[/green] btcli stake show-validator-claims --hotkey 5Grw...
+        [green]$[/green] btcli stake show-validator-claims --wallet-name my_wallet --wallet-hotkey hk
         """
         self.verbosity_handler(quiet, verbose, False, prompt)
 

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -163,7 +163,9 @@ def validate_claim_type(value: Optional[str]) -> Optional[claim_stake.ClaimType]
                 return member
         return claim_stake.ClaimType(value)
     except ValueError:
-        raise typer.BadParameter(f"'{value}' is not one of 'Keep', 'Swap'.")
+        raise typer.BadParameter(
+            f"'{value}' is not one of 'Keep', 'Swap', 'Delegated'."
+        )
 
 
 class Options:
@@ -5838,6 +5840,7 @@ class CLIManager:
         • [green]Swap[/green]: Future Root Alpha Emissions are swapped to TAO and added to root stake (default)
         • [yellow]Keep[/yellow]: Future Root Alpha Emissions are kept as Alpha tokens
         • [cyan]Keep Specific[/cyan]: Keep specific subnets as Alpha, swap others to TAO. You can use this type by selecting the netuids.
+        • [magenta]Delegated[/magenta]: Delegate claim choice to validator (inherits validator claim type)
 
         USAGE:
 
@@ -5846,6 +5849,7 @@ class CLIManager:
         [green]$[/green] btcli stake claim swap [cyan](Swap all subnets)[/cyan]
         [green]$[/green] btcli stake claim keep --netuids 1-5,10,20-30 [cyan](Keep specific subnets)[/cyan]
         [green]$[/green] btcli stake claim swap --netuids 1-30 [cyan](Swap specific subnets)[/cyan]
+        [green]$[/green] btcli stake claim delegated [cyan](Delegate claim choice to validator)[/cyan]
 
         With specific wallet:
 

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1295,6 +1295,14 @@ class CLIManager:
             "unclaim",
             hidden=True,
         )(self.stake_set_claim_type)
+        self.stake_app.command(
+            "show-validator-claim",
+            hidden=True,
+        )(self.show_validator_claims)
+        self.stake_app.command(
+            "set-validator-claim",
+            hidden=True,
+        )(self.set_validator_claim_types)
 
         # Crowdloan
         self.app.add_typer(

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -5921,7 +5921,6 @@ class CLIManager:
         prompt: bool = Options.prompt,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
-        json_output: bool = Options.json_output,
     ):
         """
         Set the claim type for a validator across multiple subnets.
@@ -5939,7 +5938,7 @@ class CLIManager:
         [green]$[/green] btcli stake set-validator-claim --keep-all
         [green]$[/green] btcli stake set-validator-claim (Interactive mode)
         """
-        self.verbosity_handler(quiet, verbose, json_output, prompt)
+        self.verbosity_handler(quiet, verbose, False, prompt)
         proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
         wallet = self.wallet_ask(
             wallet_name,
@@ -5958,7 +5957,6 @@ class CLIManager:
                 swap_all=swap_all,
                 prompt=prompt,
                 proxy=proxy,
-                json_output=json_output,
             )
         )
 

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -2099,7 +2099,7 @@ class SubtensorInterface:
 
         return claim_types
 
-    async def get_all_vali_claim_types_for_hk(
+    async def get_vali_claim_types_for_hk(
         self,
         hotkey_ss58: str,
         block_hash: Optional[str] = None,

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -2065,6 +2065,38 @@ class SubtensorInterface:
         claim_type_key = next(iter(result.keys()))
         return {"type": claim_type_key}
 
+    async def get_all_validator_claim_types(
+        self,
+        hotkey_ss58: str,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
+    ) -> dict[int, str]:
+        """
+        Retrieves validator claim types for all netuids for a given validator hotkey.
+
+        Args:
+            hotkey_ss58: Validator hotkey SS58 address.
+            block_hash: Optional block hash for the query.
+            reuse_block: Whether to reuse the last-used block hash.
+
+        Returns:
+            dict[int, str]: Mapping of netuid -> claim type ("Keep" or "Swap").
+        """
+        result = await self.substrate.query_map(
+            module="SubtensorModule",
+            storage_function="ValidatorClaimType",
+            params=[hotkey_ss58],
+            block_hash=block_hash,
+            reuse_block_hash=reuse_block,
+        )
+
+        claim_types: dict[int, str] = {}
+        async for netuid, claim_type_data in result:
+            claim_type_key = next(iter(claim_type_data.value.keys()))
+            claim_types[int(netuid)] = claim_type_key
+
+        return claim_types
+
     async def get_staking_hotkeys(
         self,
         coldkey_ss58: str,

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -2034,6 +2034,37 @@ class SubtensorInterface:
 
         return root_claim_types
 
+    async def get_validator_claim_type(
+        self,
+        hotkey_ss58: str,
+        netuid: int,
+        block_hash: Optional[str] = None,
+        reuse_block: bool = False,
+    ) -> dict:
+        """
+        Retrieves the validator claim type for a specific hotkey on a subnet.
+
+        Args:
+            hotkey_ss58: Validator hotkey SS58 address.
+            netuid: Subnet identifier.
+            block_hash: Optional block hash for the query.
+            reuse_block: Whether to reuse the last-used blockchain block hash.
+
+        Returns:
+            dict: Claim type information in one of these formats:
+                - {"type": "Swap"}
+                - {"type": "Keep"}
+        """
+        result = await self.query(
+            module="SubtensorModule",
+            storage_function="ValidatorClaimType",
+            params=[hotkey_ss58, netuid],
+            block_hash=block_hash,
+            reuse_block_hash=reuse_block,
+        )
+        claim_type_key = next(iter(result.keys()))
+        return {"type": claim_type_key}
+
     async def get_staking_hotkeys(
         self,
         coldkey_ss58: str,

--- a/bittensor_cli/src/commands/stake/claim.py
+++ b/bittensor_cli/src/commands/stake/claim.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 class ClaimType(Enum):
     Keep = "Keep"
     Swap = "Swap"
+    Delegated = "Delegated"
 
 
 async def set_claim_type(
@@ -536,17 +537,21 @@ async def _ask_for_claim_types(
             "[yellow]Options:[/yellow]\n"
             "  • [green]Swap[/green] - Convert emissions to TAO\n"
             "  • [green]Keep[/green] - Keep emissions as Alpha\n"
-            "  • [green]Keep Specific[/green] - Keep selected subnets, swap others\n",
+            "  • [green]Keep Specific[/green] - Keep selected subnets, swap others\n"
+            "  • [green]Delegated[/green] - Delegate claim choice to validator\n",
         )
     )
 
     primary_choice = Prompt.ask(
         "\nSelect new root claim type",
-        choices=["keep", "swap", "cancel"],
+        choices=["keep", "swap", "delegated", "cancel"],
         default="cancel",
     )
     if primary_choice == "cancel":
         return None
+
+    if primary_choice == "delegated":
+        return {"type": "Delegated"}
 
     apply_to_all = Confirm.ask(
         f"\nSet {primary_choice.capitalize()} to ALL subnets?", default=True
@@ -713,6 +718,10 @@ def _format_claim_type_display(
                 result += f"\n[yellow]  ⟳ Swap:[/yellow] {swap_display}"
 
         return result
+
+    elif claim_type == "Delegated":
+        return "[magenta]Delegated[/magenta]"
+
     else:
         return "[red]Unknown[/red]"
 
@@ -742,5 +751,7 @@ def _prepare_claim_type_args(claim_info: dict) -> dict:
     elif claim_type == "KeepSubnets":
         subnets = claim_info["subnets"]
         return {"KeepSubnets": {"subnets": subnets}}
+    elif claim_type == "Delegated":
+        return {"Delegated": None}
     else:
         raise ValueError(f"Unknown claim type: {claim_type}")

--- a/bittensor_cli/src/commands/stake/validator_claim.py
+++ b/bittensor_cli/src/commands/stake/validator_claim.py
@@ -14,6 +14,51 @@ from bittensor_cli.src.bittensor.utils import (
 )
 
 
+def _format_subnet_row(
+    subnet: DynamicInfo,
+    mechanisms: dict[int, int],
+    ema_tao_inflow: dict[int, Any],
+    verbose: bool,
+) -> tuple[str, ...]:
+    """
+    Format a subnet row for display in a table.
+    """
+    symbol = f"{subnet.symbol}\u200e"
+    netuid = subnet.netuid
+    price_value = f"{subnet.price.tao:,.4f}"
+
+    market_cap = (subnet.alpha_in.tao + subnet.alpha_out.tao) * subnet.price.tao
+    market_cap_value = (
+        f"{millify_tao(market_cap)}" if not verbose else f"{market_cap:,.4f}"
+    )
+
+    emission_tao = 0.0 if netuid == 0 else subnet.tao_in_emission.tao
+
+    alpha_out_value = (
+        f"{millify_tao(subnet.alpha_out.tao)}"
+        if not verbose
+        else f"{subnet.alpha_out.tao:,.4f}"
+    )
+    alpha_out_cell = (
+        f"{alpha_out_value} {symbol}" if netuid != 0 else f"{symbol} {alpha_out_value}"
+    )
+
+    ema_value = ema_tao_inflow.get(netuid).tao if netuid in ema_tao_inflow else 0.0
+
+    return (
+        str(netuid),
+        f"[{COLOR_PALETTE['GENERAL']['SYMBOL']}]"
+        f"{subnet.symbol if netuid != 0 else 'τ'}[/{COLOR_PALETTE['GENERAL']['SYMBOL']}] "
+        f"{get_subnet_name(subnet)}",
+        f"{price_value} τ/{symbol}",
+        f"τ {market_cap_value}",
+        f"τ {emission_tao:,.4f}",
+        f"τ {ema_value:,.4f}",
+        alpha_out_cell,
+        str(mechanisms.get(netuid, 1)),
+    )
+
+
 def _render_table(title: str, rows: list[tuple[str, ...]]) -> None:
     table = Table(
         title=f"\n[{COLOR_PALETTE['GENERAL']['HEADER']}]{title}[/]",

--- a/bittensor_cli/src/commands/stake/validator_claim.py
+++ b/bittensor_cli/src/commands/stake/validator_claim.py
@@ -159,7 +159,7 @@ async def show_validator_claims(
         ema_tao_inflow,
         identity,
     ) = await asyncio.gather(
-        subtensor.get_all_validator_claim_types(
+        subtensor.get_all_vali_claim_types_for_hk(
             hotkey_ss58=hotkey_value, block_hash=block_hash
         ),
         subtensor.all_subnets(block_hash=block_hash),
@@ -472,12 +472,13 @@ async def set_validator_claim_type(
 
     with console.status(":satellite: Fetching current state...", spinner="earth"):
         block_hash = await subtensor.substrate.get_chain_head()
-        current_claims, all_netuids, identity = await asyncio.gather(
-            subtensor.get_all_validator_claim_types(
+        current_claims, all_netuids, identity, testing = await asyncio.gather(
+            subtensor.get_all_vali_claim_types_for_hk(
                 hotkey_ss58=wallet.hotkey.ss58_address, block_hash=block_hash
             ),
             subtensor.get_all_subnet_netuids(block_hash=block_hash),
             subtensor.query_identity(wallet.coldkeypub.ss58_address),
+            subtensor.get_all_vali_claim_types(block_hash=block_hash),
         )
     valid_subnets = [n for n in all_netuids if n != 0]
 

--- a/bittensor_cli/src/commands/stake/validator_claim.py
+++ b/bittensor_cli/src/commands/stake/validator_claim.py
@@ -159,7 +159,7 @@ async def show_validator_claims(
         ema_tao_inflow,
         identity,
     ) = await asyncio.gather(
-        subtensor.get_all_vali_claim_types_for_hk(
+        subtensor.get_vali_claim_types_for_hk(
             hotkey_ss58=hotkey_value, block_hash=block_hash
         ),
         subtensor.all_subnets(block_hash=block_hash),
@@ -449,7 +449,7 @@ async def set_validator_claim_type(
     with console.status(":satellite: Fetching current state...", spinner="earth"):
         block_hash = await subtensor.substrate.get_chain_head()
         current_claims, all_netuids, identity, testing = await asyncio.gather(
-            subtensor.get_all_vali_claim_types_for_hk(
+            subtensor.get_vali_claim_types_for_hk(
                 hotkey_ss58=wallet.hotkey.ss58_address, block_hash=block_hash
             ),
             subtensor.get_all_subnet_netuids(block_hash=block_hash),

--- a/bittensor_cli/src/commands/stake/validator_claim.py
+++ b/bittensor_cli/src/commands/stake/validator_claim.py
@@ -1,0 +1,70 @@
+import asyncio
+from typing import Optional, Any
+
+from rich.table import Table
+from rich import box
+
+from bittensor_cli.src import COLOR_PALETTE
+from bittensor_cli.src.bittensor.chain_data import DynamicInfo
+from bittensor_cli.src.bittensor.utils import (
+    console,
+    err_console,
+    get_subnet_name,
+    millify_tao,
+)
+
+
+def _render_table(title: str, rows: list[tuple[str, ...]]) -> None:
+    table = Table(
+        title=f"\n[{COLOR_PALETTE['GENERAL']['HEADER']}]{title}[/]",
+        show_footer=False,
+        show_edge=False,
+        header_style="bold white",
+        border_style="bright_black",
+        style="bold",
+        title_justify="center",
+        show_lines=False,
+        pad_edge=True,
+        box=box.MINIMAL_DOUBLE_HEAD,
+    )
+
+    table.add_column("[bold white]Netuid", style="grey89", justify="center")
+    table.add_column("[bold white]Name", style="cyan", justify="left")
+    table.add_column(
+        "[bold white]Price \n(τ/α)",
+        style="dark_sea_green2",
+        justify="left",
+    )
+    table.add_column(
+        "[bold white]Market Cap \n(α * Price)",
+        style="steel_blue3",
+        justify="left",
+    )
+    table.add_column(
+        "[bold white]Emission (τ)",
+        style=COLOR_PALETTE["POOLS"]["EMISSION"],
+        justify="left",
+    )
+    table.add_column(
+        "[bold white]Net Inflow EMA (τ)",
+        style=COLOR_PALETTE["POOLS"]["ALPHA_OUT"],
+        justify="left",
+    )
+    table.add_column(
+        "[bold white]Stake (α_out)",
+        style=COLOR_PALETTE["STAKE"]["STAKE_ALPHA"],
+        justify="left",
+    )
+    table.add_column(
+        "[bold white]Mechanisms",
+        style=COLOR_PALETTE["GENERAL"]["SUBHEADING_EXTRA_1"],
+        justify="center",
+    )
+
+    if not rows:
+        table.add_row("~", "No subnets", "-", "-", "-", "-", "-", "-")
+    else:
+        for row in rows:
+            table.add_row(*row)
+
+    console.print(table)

--- a/bittensor_cli/src/commands/stake/validator_claim.py
+++ b/bittensor_cli/src/commands/stake/validator_claim.py
@@ -227,3 +227,44 @@ async def set_validator_claim_type(
     Returns:
         bool: True if the operation succeeded, False otherwise.
     """
+
+    def _render_current_claims(
+        state: dict[int, str],
+        identity: dict = None,
+        ss58: str = None,
+    ):
+        validator_name = identity.get("name", "Unknown")
+        header_text = (
+            f"[dim]Validator:[/dim] [bold cyan]{validator_name}[/bold cyan]\n"
+            f"[dim]({ss58})[/dim]"
+        )
+        console.print(header_text, "\n")
+
+        default_list = sorted([n for n, t in state.items() if t == "Default"])
+        keep_list = sorted([n for n, t in state.items() if t == "Keep"])
+        swap_list = sorted([n for n, t in state.items() if t == "Swap"])
+
+        default_str = group_subnets(default_list) if default_list else "[dim]None[/dim]"
+        keep_str = group_subnets(keep_list) if keep_list else "[dim]None[/dim]"
+        swap_str = group_subnets(swap_list) if swap_list else "[dim]None[/dim]"
+
+        default_panel = Panel(
+            default_str,
+            title="[bold blue]Default (Keep - α)[/bold blue]",
+            border_style="blue",
+            expand=False,
+        )
+        keep_panel = Panel(
+            keep_str,
+            title="[bold green]Keep (α)[/bold green]",
+            border_style="green",
+            expand=False,
+        )
+        swap_panel = Panel(
+            swap_str,
+            title="[bold red]Swap (τ)[/bold red]",
+            border_style="red",
+            expand=False,
+        )
+
+        top_row = Columns([keep_panel, swap_panel], expand=False, equal=True)

--- a/bittensor_cli/src/commands/stake/validator_claim.py
+++ b/bittensor_cli/src/commands/stake/validator_claim.py
@@ -211,7 +211,6 @@ async def set_validator_claim_type(
     swap_all: bool = False,
     prompt: bool = True,
     proxy: Optional[str] = None,
-    json_output: bool = False,
 ) -> bool:
     """
     Configures the validator claim preference (Keep vs Swap) for subnets.
@@ -355,38 +354,15 @@ async def set_validator_claim_type(
             )
 
             if success:
-                if json_output:
-                    json_console.print(
-                        json.dumps(
-                            {
-                                "success": True,
-                                "message": "Successfully updated validator claim types",
-                                "extrinsic_hash": ext_receipt.extrinsic_hash,
-                                "changes": [{"netuid": n, "type": t} for n, t in calls],
-                            }
-                        )
-                    )
-                else:
-                    console.print(
-                        "[green]:white_check_mark: Successfully updated validator claim types![/green]"
-                    )
-                    await print_extrinsic_id(ext_receipt)
+                console.print(
+                    "[green]:white_check_mark: Successfully updated validator claim types![/green]"
+                )
+                await print_extrinsic_id(ext_receipt)
                 return True
             else:
-                if json_output:
-                    json_console.print(
-                        json.dumps(
-                            {
-                                "success": False,
-                                "message": f"Transaction Failed: {err_msg}",
-                                "error": err_msg,
-                            }
-                        )
-                    )
-                else:
-                    err_console.print(
-                        f"[red]:cross_mark: Transaction Failed: {err_msg}[/red]"
-                    )
+                err_console.print(
+                    f"[red]:cross_mark: Transaction Failed: {err_msg}[/red]"
+                )
                 return False
 
     def _interactive_claim_selector(

--- a/bittensor_cli/src/commands/stake/validator_claim.py
+++ b/bittensor_cli/src/commands/stake/validator_claim.py
@@ -1,7 +1,12 @@
+import json
 import asyncio
 from typing import Optional, Any
-
+from rich.prompt import Confirm, Prompt
+from rich.panel import Panel
 from rich.table import Table
+from rich.columns import Columns
+from rich.text import Text
+from rich.console import Group
 from rich import box
 
 from bittensor_cli.src import COLOR_PALETTE
@@ -11,6 +16,11 @@ from bittensor_cli.src.bittensor.utils import (
     err_console,
     get_subnet_name,
     millify_tao,
+    parse_subnet_range,
+    group_subnets,
+    unlock_key,
+    print_extrinsic_id,
+    json_console,
 )
 
 
@@ -19,12 +29,120 @@ async def show_validator_claims(
     hotkey_ss58: Optional[str] = None,
     block_hash: Optional[str] = None,
     verbose: bool = False,
+    json_output: bool = False,
 ) -> None:
     """
-    Display validator claim types (Keep/Swap) for all subnets of a validator hotkey.
-    Renders two tables: Keep & Swap based on subnet claim type.
+    Displays the validator claim configuration (Keep vs Swap) for a given hotkey's subnets.
+
+    This function fetches the current claim status for all subnets where the validator has presence.
+
+    Args:
+        subtensor: The subtensor interface for chain interaction.
+        hotkey_ss58: The SS58 address of the validator's hotkey.
+        block_hash: Optional block hash to query state at.
+        verbose: If True, displays full precision values.
+        json_output: If True, prints JSON to stdout and suppresses table render.
     """
 
+    def _format_subnet_row(
+        subnet: DynamicInfo,
+        mechanisms: dict[int, int],
+        ema_tao_inflow: dict[int, Any],
+        verbose: bool,
+    ) -> tuple[str, ...]:
+        symbol = f"{subnet.symbol}\u200e"
+        netuid = subnet.netuid
+        price_value = f"{subnet.price.tao:,.4f}"
+
+        market_cap = (subnet.alpha_in.tao + subnet.alpha_out.tao) * subnet.price.tao
+        market_cap_value = (
+            f"{millify_tao(market_cap)}" if not verbose else f"{market_cap:,.4f}"
+        )
+
+        emission_tao = 0.0 if netuid == 0 else subnet.tao_in_emission.tao
+
+        alpha_out_value = (
+            f"{millify_tao(subnet.alpha_out.tao)}"
+            if not verbose
+            else f"{subnet.alpha_out.tao:,.4f}"
+        )
+        alpha_out_cell = (
+            f"{alpha_out_value} {symbol}"
+            if netuid != 0
+            else f"{symbol} {alpha_out_value}"
+        )
+
+        ema_value = ema_tao_inflow.get(netuid).tao if netuid in ema_tao_inflow else 0.0
+
+        return (
+            str(netuid),
+            f"[{COLOR_PALETTE['GENERAL']['SYMBOL']}]"
+            f"{subnet.symbol if netuid != 0 else 'τ'}[/{COLOR_PALETTE['GENERAL']['SYMBOL']}] "
+            f"{get_subnet_name(subnet)}",
+            f"{price_value} τ/{symbol}",
+            f"τ {market_cap_value}",
+            f"τ {emission_tao:,.4f}",
+            f"τ {ema_value:,.4f}",
+            alpha_out_cell,
+            str(mechanisms.get(netuid, 1)),
+        )
+
+    def _render_table(title: str, rows: list[tuple[str, ...]]) -> None:
+        table = Table(
+            title=f"\n[{COLOR_PALETTE['GENERAL']['HEADER']}]{title}[/]",
+            show_footer=False,
+            show_edge=False,
+            header_style="bold white",
+            border_style="bright_black",
+            style="bold",
+            title_justify="center",
+            show_lines=False,
+            pad_edge=True,
+            box=box.MINIMAL_DOUBLE_HEAD,
+        )
+
+        table.add_column("[bold white]Netuid", style="grey89", justify="center")
+        table.add_column("[bold white]Name", style="cyan", justify="left")
+        table.add_column(
+            "[bold white]Price \n(τ/α)",
+            style="dark_sea_green2",
+            justify="left",
+        )
+        table.add_column(
+            "[bold white]Market Cap \n(α * Price)",
+            style="steel_blue3",
+            justify="left",
+        )
+        table.add_column(
+            "[bold white]Emission (τ)",
+            style=COLOR_PALETTE["POOLS"]["EMISSION"],
+            justify="left",
+        )
+        table.add_column(
+            "[bold white]Net Inflow EMA (τ)",
+            style=COLOR_PALETTE["POOLS"]["ALPHA_OUT"],
+            justify="left",
+        )
+        table.add_column(
+            "[bold white]Stake (α_out)",
+            style=COLOR_PALETTE["STAKE"]["STAKE_ALPHA"],
+            justify="left",
+        )
+        table.add_column(
+            "[bold white]Mechanisms",
+            style=COLOR_PALETTE["GENERAL"]["SUBHEADING_EXTRA_1"],
+            justify="center",
+        )
+
+        if not rows:
+            table.add_row("~", "No subnets", "-", "-", "-", "-", "-", "-")
+        else:
+            for row in rows:
+                table.add_row(*row)
+
+        console.print(table)
+
+    # Main function
     hotkey_value = hotkey_ss58
     if not hotkey_value:
         err_console.print("[red]Hotkey SS58 address is required.[/red]")
@@ -51,7 +169,6 @@ async def show_validator_claims(
 
     keep_rows = []
     swap_rows = []
-
     for subnet in sorted_subnets:
         claim_type = validator_claims.get(subnet.netuid, "Keep")
         row = _format_subnet_row(subnet, mechanisms, ema_tao_inflow, verbose)
@@ -60,106 +177,16 @@ async def show_validator_claims(
         else:
             keep_rows.append(row)
 
+    if json_output:
+        output_data = {
+            "hotkey": hotkey_value,
+            "claims": {},
+        }
+        for subnet in sorted_subnets:
+            claim_type = validator_claims.get(subnet.netuid, "Keep")
+            output_data["claims"][subnet.netuid] = claim_type
+        json_console.print(json.dumps(output_data))
+
     _render_table("Keep", keep_rows)
     _render_table("[red]Swap[/red]", swap_rows)
-
-
-def _format_subnet_row(
-    subnet: DynamicInfo,
-    mechanisms: dict[int, int],
-    ema_tao_inflow: dict[int, Any],
-    verbose: bool,
-) -> tuple[str, ...]:
-    """
-    Format a subnet row for display in a table.
-    """
-    symbol = f"{subnet.symbol}\u200e"
-    netuid = subnet.netuid
-    price_value = f"{subnet.price.tao:,.4f}"
-
-    market_cap = (subnet.alpha_in.tao + subnet.alpha_out.tao) * subnet.price.tao
-    market_cap_value = (
-        f"{millify_tao(market_cap)}" if not verbose else f"{market_cap:,.4f}"
-    )
-
-    emission_tao = 0.0 if netuid == 0 else subnet.tao_in_emission.tao
-
-    alpha_out_value = (
-        f"{millify_tao(subnet.alpha_out.tao)}"
-        if not verbose
-        else f"{subnet.alpha_out.tao:,.4f}"
-    )
-    alpha_out_cell = (
-        f"{alpha_out_value} {symbol}" if netuid != 0 else f"{symbol} {alpha_out_value}"
-    )
-
-    ema_value = ema_tao_inflow.get(netuid).tao if netuid in ema_tao_inflow else 0.0
-
-    return (
-        str(netuid),
-        f"[{COLOR_PALETTE['GENERAL']['SYMBOL']}]"
-        f"{subnet.symbol if netuid != 0 else 'τ'}[/{COLOR_PALETTE['GENERAL']['SYMBOL']}] "
-        f"{get_subnet_name(subnet)}",
-        f"{price_value} τ/{symbol}",
-        f"τ {market_cap_value}",
-        f"τ {emission_tao:,.4f}",
-        f"τ {ema_value:,.4f}",
-        alpha_out_cell,
-        str(mechanisms.get(netuid, 1)),
-    )
-
-
-def _render_table(title: str, rows: list[tuple[str, ...]]) -> None:
-    table = Table(
-        title=f"\n[{COLOR_PALETTE['GENERAL']['HEADER']}]{title}[/]",
-        show_footer=False,
-        show_edge=False,
-        header_style="bold white",
-        border_style="bright_black",
-        style="bold",
-        title_justify="center",
-        show_lines=False,
-        pad_edge=True,
-        box=box.MINIMAL_DOUBLE_HEAD,
-    )
-
-    table.add_column("[bold white]Netuid", style="grey89", justify="center")
-    table.add_column("[bold white]Name", style="cyan", justify="left")
-    table.add_column(
-        "[bold white]Price \n(τ/α)",
-        style="dark_sea_green2",
-        justify="left",
-    )
-    table.add_column(
-        "[bold white]Market Cap \n(α * Price)",
-        style="steel_blue3",
-        justify="left",
-    )
-    table.add_column(
-        "[bold white]Emission (τ)",
-        style=COLOR_PALETTE["POOLS"]["EMISSION"],
-        justify="left",
-    )
-    table.add_column(
-        "[bold white]Net Inflow EMA (τ)",
-        style=COLOR_PALETTE["POOLS"]["ALPHA_OUT"],
-        justify="left",
-    )
-    table.add_column(
-        "[bold white]Stake (α_out)",
-        style=COLOR_PALETTE["STAKE"]["STAKE_ALPHA"],
-        justify="left",
-    )
-    table.add_column(
-        "[bold white]Mechanisms",
-        style=COLOR_PALETTE["GENERAL"]["SUBHEADING_EXTRA_1"],
-        justify="center",
-    )
-
-    if not rows:
-        table.add_row("~", "No subnets", "-", "-", "-", "-", "-", "-")
-    else:
-        for row in rows:
-            table.add_row(*row)
-
-    console.print(table)
+    return True

--- a/bittensor_cli/src/commands/stake/validator_claim.py
+++ b/bittensor_cli/src/commands/stake/validator_claim.py
@@ -268,3 +268,34 @@ async def set_validator_claim_type(
         )
 
         top_row = Columns([keep_panel, swap_panel], expand=False, equal=True)
+
+        total = len(state)
+        default_count = len(default_list)
+        keep_count = len(keep_list)
+        swap_count = len(swap_list)
+
+        if total > 0:
+            effective_keep_count = keep_count + default_count
+
+            keep_pct = effective_keep_count / total
+            bar_width = 30
+            keep_chars = int(bar_width * keep_pct)
+            swap_chars = bar_width - keep_chars
+
+            bar_visual = (
+                f"[{'green' if effective_keep_count > 0 else 'dim'}]"
+                f"{'█' * keep_chars}[/]"
+                f"[{'red' if swap_count > 0 else 'dim'}]"
+                f"{'█' * swap_chars}[/]"
+            )
+
+            dist_text = (
+                f"\n[bold]Distribution:[/bold] {bar_visual} "
+                f"[green]{effective_keep_count}[/green] vs [red]{swap_count}[/red]\n"
+            )
+        else:
+            dist_text = ""
+
+        console.print(Group(top_row, default_panel, Text.from_markup(dist_text)))
+
+    

--- a/bittensor_cli/src/commands/stake/validator_claim.py
+++ b/bittensor_cli/src/commands/stake/validator_claim.py
@@ -298,4 +298,13 @@ async def set_validator_claim_type(
 
         console.print(Group(top_row, default_panel, Text.from_markup(dist_text)))
 
-    
+    def _print_changes_table(calls: list[tuple[int, str]]):
+        table = Table(title="Pending Root Claim Changes", box=box.SIMPLE_HEAD, width=50)
+        table.add_column("Netuid", justify="center", style="cyan")
+        table.add_column("New Type", justify="center")
+
+        for netuid, new_type in sorted(calls, key=lambda x: x[0]):
+            color = "green" if new_type == "Keep" else "red"
+            table.add_row(str(netuid), f"[{color}]{new_type}[/{color}]")
+
+        console.print("\n\n", table)

--- a/bittensor_cli/src/commands/stake/validator_claim.py
+++ b/bittensor_cli/src/commands/stake/validator_claim.py
@@ -190,3 +190,40 @@ async def show_validator_claims(
     _render_table("Keep", keep_rows)
     _render_table("[red]Swap[/red]", swap_rows)
     return True
+
+
+async def set_validator_claim_type(
+    wallet,
+    subtensor,
+    keep: Optional[str] = None,
+    swap: Optional[str] = None,
+    keep_all: bool = False,
+    swap_all: bool = False,
+    prompt: bool = True,
+    proxy: Optional[str] = None,
+    json_output: bool = False,
+) -> bool:
+    """
+    Configures the validator claim preference (Keep vs Swap) for subnets.
+
+    Allows bulk updating of claim types for multiple subnets. Subnets set to 'Keep' will accumulate
+    emissions as Alpha (subnet token), while 'Swap' will automatically convert emissions to TAO.
+
+    Operates in two modes:
+    1. CLI Mode: Updates specific ranges via `--keep` and `--swap` flags.
+    2. Interactive Mode: Launches a claim selector if no range flags are provided.
+
+    Args:
+        wallet: The wallet configuration.
+        subtensor: The subtensor interface.
+        keep: Range info string for subnets to set to 'Keep'.
+        swap: Range info string for subnets to set to 'Swap'.
+        keep_all: If True, sets all valid subnets to 'Keep'.
+        swap_all: If True, sets all valid subnets to 'Swap'.
+        prompt: If True, requires confirmation before submitting extrinsic.
+        proxy: Optional proxy address for signing.
+        json_output: If True, outputs result as JSON.
+
+    Returns:
+        bool: True if the operation succeeded, False otherwise.
+    """

--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -1296,7 +1296,7 @@ async def show(
                 subtensor.get_hyperparameter(
                     param_name="Burn", netuid=netuid_, block_hash=block_hash
                 ),
-                subtensor.get_all_validator_claim_types(block_hash=block_hash),
+                subtensor.get_all_vali_claim_types(block_hash=block_hash),
                 subtensor.get_subnet_ema_tao_inflow(
                     netuid=netuid_, block_hash=block_hash
                 ),

--- a/tests/e2e_tests/test_claim_types.py
+++ b/tests/e2e_tests/test_claim_types.py
@@ -1,0 +1,170 @@
+"""
+Verify commands:
+
+* btcli stake set-claim swap
+* btcli stake set-claim keep
+* btcli stake set-claim keep --netuids 2-4
+* btcli stake set-claim delegated
+* btcli stake set-validator-claims --swap 2-4
+* btcli stake set-validator-claims --keep 1-3
+"""
+
+
+def test_claim_type_flows(local_chain, wallet_setup):
+    """
+    Cover root claim type transitions (Swap, Keep, KeepSubnets, Delegated)
+    and validator claim type settings using the CLI.
+    """
+
+    # Wallet setup
+    keypair_alice, wallet_alice, wallet_path_alice, exec_command_alice = wallet_setup(
+        "//Alice"
+    )
+
+    # Create multiple subnets
+    for netuid in [2, 3, 4]:
+        result = exec_command_alice(
+            command="subnets",
+            sub_command="create",
+            extra_args=[
+                "--wallet-path",
+                wallet_path_alice,
+                "--chain",
+                "ws://127.0.0.1:9945",
+                "--wallet-name",
+                wallet_alice.name,
+                "--wallet-hotkey",
+                wallet_alice.hotkey_str,
+                "--subnet-name",
+                "Test Subnet",
+                "--repo",
+                "https://github.com/username/repo",
+                "--contact",
+                "test@opentensor.dev",
+                "--url",
+                "https://testsubnet.com",
+                "--discord",
+                "test#1234",
+                "--description",
+                "A test subnet for e2e testing",
+                "--logo-url",
+                "https://testsubnet.com/logo.png",
+                "--additional-info",
+                "Test subnet",
+                "--no-prompt",
+                "--no-mev-protection",
+            ],
+        )
+        assert f"✅ Registered subnetwork with netuid: {netuid}" in result.stdout
+
+    # 1) Set to Swap (as a holder)
+    swap_result = exec_command_alice(
+        command="stake",
+        sub_command="set-claim",
+        extra_args=[
+            "swap",
+            "--wallet-name",
+            wallet_alice.name,
+            "--wallet-path",
+            wallet_path_alice,
+            "--network",
+            "ws://127.0.0.1:9945",
+            "--no-prompt",
+        ],
+    )
+    assert "✅ Successfully changed claim type" in swap_result.stdout
+
+    # 2) Set to Keep (as a holder)
+    keep_result = exec_command_alice(
+        command="stake",
+        sub_command="set-claim",
+        extra_args=[
+            "keep",
+            "--wallet-name",
+            wallet_alice.name,
+            "--wallet-path",
+            wallet_path_alice,
+            "--network",
+            "ws://127.0.0.1:9945",
+            "--no-prompt",
+        ],
+    )
+    assert "✅ Successfully changed claim type" in keep_result.stdout
+
+    # 3) Set to KeepSubnets (as a holder)
+    keep_subnets_result = exec_command_alice(
+        command="stake",
+        sub_command="set-claim",
+        extra_args=[
+            "keep",
+            "--netuids",
+            "1-3",
+            "--wallet-name",
+            wallet_alice.name,
+            "--wallet-path",
+            wallet_path_alice,
+            "--network",
+            "ws://127.0.0.1:9945",
+            "--no-prompt",
+        ],
+    )
+    assert "✅ Successfully changed claim type" in keep_subnets_result.stdout
+
+    # 4) Set to Delegated (as a holder)
+    delegated_result = exec_command_alice(
+        command="stake",
+        sub_command="set-claim",
+        extra_args=[
+            "delegated",
+            "--wallet-name",
+            wallet_alice.name,
+            "--wallet-path",
+            wallet_path_alice,
+            "--network",
+            "ws://127.0.0.1:9945",
+            "--no-prompt",
+        ],
+    )
+    assert "✅ Successfully changed claim type" in delegated_result.stdout
+
+    # 5) Validator claim (as a validator)
+    validator_claim_swap_result = exec_command_alice(
+        command="stake",
+        sub_command="set-validator-claims",
+        extra_args=[
+            "--swap",
+            "1-3",
+            "--wallet-name",
+            wallet_alice.name,
+            "--wallet-path",
+            wallet_path_alice,
+            "--network",
+            "ws://127.0.0.1:9945",
+            "--no-prompt",
+        ],
+    )
+    assert (
+        "✅ Successfully updated validator claim types"
+        in validator_claim_swap_result.stdout
+    )
+
+    # 6) Validator claim (as a validator)
+    validator_claim_keep_result = exec_command_alice(
+        command="stake",
+        sub_command="set-validator-claims",
+        extra_args=[
+            "--keep",
+            "1-3",
+            "--wallet-name",
+            wallet_alice.name,
+            "--wallet-path",
+            wallet_path_alice,
+            "--network",
+            "ws://127.0.0.1:9945",
+            "--no-prompt",
+        ],
+    )
+    assert (
+        "✅ Successfully updated validator claim types"
+        in validator_claim_keep_result.stdout
+    )


### PR DESCRIPTION
## Delegated Claim type

## Updated commands

### 1. `btcli stake set-claim delegated`
> [!IMPORTANT]
> Allows setting of new 'delegated' type for claim settings

<img width="604" height="370" alt="image" src="https://github.com/user-attachments/assets/6578da6c-477b-4fbf-bb4f-d10b2c135c20" />

### 2. `btcli stake show-validator-claims`
> [!IMPORTANT]
> Displays current keep/swap configuration for a specific validator
> Can pass in ss58 address of the validator's hotkey as well

<img width="953" height="492" alt="image" src="https://github.com/user-attachments/assets/30aea0c6-c7d0-4fcf-9be5-6eac72a27555" />

### 3. `btcli stake set-validator-claims --keep 2-6 `
> [!IMPORTANT]
> Allows validators to change claim settings of specific subnets 
> Can use `--swap 3-4` etc as well

<img width="577" height="500" alt="image" src="https://github.com/user-attachments/assets/6e2a2fad-ff17-45ea-a934-5ae68b5811ed" />

### 4. `btcli stake set-validator-claims ` (Interactive mode)
> [!IMPORTANT]
> Opens a wizard to update validator claim types. 
> Allows validators to see current status at a glance and keep updating types until they have finalized their selections
> Performs a batch call to execute all choices in one call

<img width="499" height="1024" alt="image" src="https://github.com/user-attachments/assets/166738b7-712b-4f57-bdd6-6323b44c6a5c" />

### 5. `btcli subnets metagraph --netuid 3`
> [!IMPORTANT]
> Metagraph command now displays each validator's claim setting for that subnet

<img width="1145" height="450" alt="image" src="https://github.com/user-attachments/assets/ca0b6700-1c11-425b-a6fe-a299a6dc27ef" />
