### PR TITLE
Feat/slip39 shamir secret sharing 407

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -108,6 +108,7 @@ from bittensor_cli.src.commands.subnets import (
     mechanisms as subnet_mechanisms,
 )
 from bittensor_cli.src.commands.axon import axon
+from bittensor_cli.src.bittensor import slip39 as slip39_utils
 from bittensor_cli.version import __version__, __version_as_int__
 
 try:
@@ -1024,6 +1025,12 @@ class CLIManager:
         self.wallet_app.command(
             "new-coldkey", rich_help_panel=HELP_PANELS["WALLET"]["MANAGEMENT"]
         )(self.wallet_new_coldkey)
+        self.wallet_app.command(
+            "new-coldkey-slip39", rich_help_panel=HELP_PANELS["WALLET"]["SECURITY"]
+        )(self.wallet_new_coldkey_slip39)
+        self.wallet_app.command(
+            "recover-coldkey-slip39", rich_help_panel=HELP_PANELS["WALLET"]["SECURITY"]
+        )(self.wallet_recover_coldkey_slip39)
         self.wallet_app.command(
             "associate-hotkey", rich_help_panel=HELP_PANELS["WALLET"]["MANAGEMENT"]
         )(self.wallet_associate_hotkey)
@@ -3436,6 +3443,396 @@ class CLIManager:
                 wallet, n_words, use_password, uri, overwrite, json_output
             )
         )
+
+    def wallet_new_coldkey_slip39(
+        self,
+        wallet_name: Optional[str] = Options.wallet_name,
+        wallet_path: Optional[str] = Options.wallet_path,
+        shares: int = typer.Option(
+            5,
+            "--shares",
+            "-s",
+            help="Total number of SLIP39 shares to generate",
+        ),
+        threshold: int = typer.Option(
+            3,
+            "--threshold",
+            "-t",
+            help="Minimum number of shares required to recover the coldkey",
+        ),
+        passphrase: Optional[str] = typer.Option(
+            None,
+            "--passphrase",
+            "--slip39-passphrase",
+            help="Optional passphrase for additional security (you must remember this to recover)",
+        ),
+        output_dir: Optional[str] = typer.Option(
+            None,
+            "--output-dir",
+            "-o",
+            help="Directory to save share files (if not specified, shares are displayed on screen)",
+        ),
+        show_shares: bool = typer.Option(
+            False,
+            "--show-shares",
+            help="Display the full mnemonic shares on screen (use with caution)",
+        ),
+        use_password: Optional[bool] = Options.use_password,
+        overwrite: bool = Options.overwrite,
+        quiet: bool = Options.quiet,
+        verbose: bool = Options.verbose,
+        json_output: bool = Options.json_output,
+    ):
+        """
+        Create a new coldkey using SLIP39 (Shamir's Secret Sharing).
+
+        This command creates a new coldkey and splits the secret into multiple
+        mnemonic shares using SLIP39. The plaintext seed phrase is NEVER exposed.
+
+        SLIP39 allows you to split your secret into N shares where M shares are
+        required to recover the original secret (M-of-N threshold scheme).
+
+        USAGE
+
+        Create a coldkey with 3-of-5 shares (default):
+        [green]$[/green] btcli wallet new-coldkey-slip39
+
+        Create a coldkey with 2-of-3 shares:
+        [green]$[/green] btcli wallet new-coldkey-slip39 --shares 3 --threshold 2
+
+        Save shares to files instead of displaying:
+        [green]$[/green] btcli wallet new-coldkey-slip39 --output-dir /secure/location
+
+        Add passphrase protection:
+        [green]$[/green] btcli wallet new-coldkey-slip39 --passphrase "my secret phrase"
+
+        [bold]SECURITY NOTES[/bold]
+
+        • Each share should be stored in a separate secure location
+        • Distribute shares to different custodians for maximum security
+        • The passphrase (if used) must be remembered - it cannot be recovered
+        • Never store all shares together or in digital form on one device
+        • This eliminates risk of screen reader and keylogger attacks since
+          the seed phrase is never exposed in plaintext
+        """
+        self.verbosity_handler(quiet, verbose, json_output, False)
+
+        if threshold > shares:
+            err_console.print(
+                f":cross_mark: [red]Threshold ({threshold}) cannot be greater than "
+                f"total shares ({shares})[/red]"
+            )
+            raise typer.Exit(1)
+
+        if threshold < 1:
+            err_console.print(":cross_mark: [red]Threshold must be at least 1[/red]")
+            raise typer.Exit(1)
+
+        if shares < 1 or shares > 16:
+            err_console.print(
+                ":cross_mark: [red]Number of shares must be between 1 and 16[/red]"
+            )
+            raise typer.Exit(1)
+
+        if not wallet_path:
+            wallet_path = Prompt.ask(
+                "Enter the path to the wallets directory",
+                default=self.config.get("wallet_path") or defaults.wallet.path,
+            )
+
+        if not wallet_name:
+            wallet_name = Prompt.ask(
+                f"Enter the name of the [{COLORS.G.CK}]new wallet (coldkey)",
+                default=self.config.get("wallet_name") or defaults.wallet.name,
+            )
+
+        wallet = self.wallet_ask(
+            wallet_name,
+            wallet_path,
+            None,
+            ask_for=[WO.NAME, WO.PATH],
+            validate=WV.NONE,
+        )
+
+        # Configure SLIP39
+        config = slip39_utils.SLIP39Config(
+            group_threshold=1,
+            groups=[(threshold, shares)],
+            passphrase=passphrase or "",
+        )
+
+        try:
+            # Create coldkey with SLIP39 shares
+            share_set, keypair = slip39_utils.create_coldkey_with_slip39(
+                wallet=wallet,
+                config=config,
+                use_password=use_password if use_password is not None else True,
+                overwrite=overwrite,
+            )
+
+            if json_output:
+                output_data = {
+                    "success": True,
+                    "data": {
+                        "name": wallet.name,
+                        "path": wallet.path,
+                        "coldkey_ss58": keypair.ss58_address,
+                        "threshold": threshold,
+                        "total_shares": shares,
+                        "identifier": share_set.identifier,
+                    },
+                    "error": "",
+                }
+
+                if output_dir:
+                    # Save shares to files
+                    created_files = slip39_utils.save_shares_to_files(
+                        share_set, output_dir, prefix=wallet_name
+                    )
+                    output_data["data"]["share_files"] = [str(f) for f in created_files]
+                elif show_shares:
+                    output_data["data"]["shares"] = share_set.all_shares_flat()
+
+                console.print_json(data=output_data)
+            else:
+                console.print(
+                    "\n:white_check_mark: [green]Coldkey created successfully![/green]"
+                )
+                console.print(f"[bold]Wallet:[/bold] {wallet.name}")
+                console.print(f"[bold]Path:[/bold] {wallet.path}")
+                console.print(
+                    f"[bold]SS58 Address:[/bold] [{COLORS.G.CK}]{keypair.ss58_address}[/{COLORS.G.CK}]"
+                )
+
+                if output_dir:
+                    # Save shares to files
+                    created_files = slip39_utils.save_shares_to_files(
+                        share_set, output_dir, prefix=wallet_name
+                    )
+                    console.print(
+                        f"\n[bold green]Shares saved to {len(created_files)} files:[/bold green]"
+                    )
+                    for f in created_files:
+                        console.print(f"  • {f}")
+                    console.print(
+                        "\n[bold yellow]⚠ Distribute these files to separate secure locations![/bold yellow]"
+                    )
+                else:
+                    # Display shares on screen
+                    slip39_utils.print_shares_securely(
+                        share_set, show_shares=show_shares
+                    )
+
+        except Exception as e:
+            if json_output:
+                console.print_json(
+                    data={"success": False, "error": str(e), "data": None}
+                )
+            else:
+                err_console.print(
+                    f":cross_mark: [red]Failed to create coldkey: {e}[/red]"
+                )
+            raise typer.Exit(1)
+
+    def wallet_recover_coldkey_slip39(
+        self,
+        wallet_name: Optional[str] = Options.wallet_name,
+        wallet_path: Optional[str] = Options.wallet_path,
+        share_files: Optional[list[str]] = typer.Option(
+            None,
+            "--share-file",
+            "-f",
+            help="Path to a SLIP39 share file (can be specified multiple times)",
+        ),
+        passphrase: Optional[str] = typer.Option(
+            None,
+            "--passphrase",
+            "--slip39-passphrase",
+            help="Passphrase used during share generation (if any)",
+        ),
+        use_password: Optional[bool] = Options.use_password,
+        overwrite: bool = Options.overwrite,
+        quiet: bool = Options.quiet,
+        verbose: bool = Options.verbose,
+        json_output: bool = Options.json_output,
+    ):
+        """
+        Recover a coldkey from SLIP39 mnemonic shares.
+
+        This command recovers a coldkey by combining SLIP39 mnemonic shares.
+        You need to provide at least the threshold number of shares that were
+        specified when the coldkey was created.
+
+        USAGE
+
+        Recover from share files:
+        [green]$[/green] btcli wallet recover-coldkey-slip39 -f share1.slip39 -f share2.slip39 -f share3.slip39
+
+        Recover with passphrase:
+        [green]$[/green] btcli wallet recover-coldkey-slip39 -f share1.slip39 -f share2.slip39 --passphrase "my secret"
+
+        Enter shares interactively:
+        [green]$[/green] btcli wallet recover-coldkey-slip39
+
+        [bold]SECURITY NOTES[/bold]
+
+        • Only combine shares on a secure, air-gapped machine if possible
+        • The recovered coldkey will be encrypted with a password (recommended)
+        • If a passphrase was used during creation, you must provide it here
+        """
+        self.verbosity_handler(quiet, verbose, json_output, False)
+
+        if not wallet_path:
+            wallet_path = Prompt.ask(
+                "Enter the path to the wallets directory",
+                default=self.config.get("wallet_path") or defaults.wallet.path,
+            )
+
+        if not wallet_name:
+            wallet_name = Prompt.ask(
+                f"Enter the name for the recovered [{COLORS.G.CK}]wallet (coldkey)",
+                default=self.config.get("wallet_name") or defaults.wallet.name,
+            )
+
+        wallet = self.wallet_ask(
+            wallet_name,
+            wallet_path,
+            None,
+            ask_for=[WO.NAME, WO.PATH],
+            validate=WV.NONE,
+        )
+
+        # Collect shares
+        shares = []
+
+        if share_files:
+            # Load shares from files
+            try:
+                shares = slip39_utils.load_shares_from_files(share_files)
+                if not json_output:
+                    console.print(f"[dim]Loaded {len(shares)} shares from files[/dim]")
+            except FileNotFoundError as e:
+                if json_output:
+                    console.print_json(
+                        data={"success": False, "error": str(e), "data": None}
+                    )
+                else:
+                    err_console.print(f":cross_mark: [red]{e}[/red]")
+                raise typer.Exit(1)
+        else:
+            # Interactive share entry
+            if not json_output:
+                console.print(
+                    "\n[bold cyan]Enter your SLIP39 mnemonic shares[/bold cyan]"
+                )
+                console.print(
+                    "[dim]Enter each share on a single line. Type 'done' when finished.[/dim]\n"
+                )
+
+            share_num = 1
+            while True:
+                try:
+                    share = Prompt.ask(f"Share {share_num}")
+                    if share.lower() == "done":
+                        break
+                    if share.strip():
+                        # Validate the share
+                        validation = slip39_utils.validate_shares([share])
+                        if validation["valid"]:
+                            shares.append(share.strip())
+                            share_num += 1
+                        else:
+                            err_console.print(
+                                f"[yellow]Invalid share: {validation.get('error', 'Unknown error')}[/yellow]"
+                            )
+                except KeyboardInterrupt:
+                    console.print("\n[dim]Cancelled[/dim]")
+                    raise typer.Exit(0)
+
+        if not shares:
+            if json_output:
+                console.print_json(
+                    data={"success": False, "error": "No shares provided", "data": None}
+                )
+            else:
+                err_console.print(":cross_mark: [red]No shares provided[/red]")
+            raise typer.Exit(1)
+
+        # Validate all shares together
+        validation = slip39_utils.validate_shares(shares)
+        if not validation["valid"]:
+            if json_output:
+                console.print_json(
+                    data={
+                        "success": False,
+                        "error": validation.get("error", "Invalid shares"),
+                        "data": None,
+                    }
+                )
+            else:
+                err_console.print(
+                    f":cross_mark: [red]Invalid shares: {validation.get('error')}[/red]"
+                )
+            raise typer.Exit(1)
+
+        if not json_output:
+            console.print(
+                f"\n[dim]Share set identifier: {validation['identifier']}[/dim]"
+            )
+            console.print(f"[dim]Shares provided: {validation['share_count']}[/dim]")
+
+        try:
+            # Recover the coldkey
+            keypair = slip39_utils.recover_coldkey_from_slip39(
+                wallet=wallet,
+                shares=shares,
+                passphrase=passphrase or "",
+                use_password=use_password if use_password is not None else True,
+                overwrite=overwrite,
+            )
+
+            if json_output:
+                console.print_json(
+                    data={
+                        "success": True,
+                        "data": {
+                            "name": wallet.name,
+                            "path": wallet.path,
+                            "coldkey_ss58": keypair.ss58_address,
+                        },
+                        "error": "",
+                    }
+                )
+            else:
+                console.print(
+                    "\n:white_check_mark: [green]Coldkey recovered successfully![/green]"
+                )
+                console.print(f"[bold]Wallet:[/bold] {wallet.name}")
+                console.print(f"[bold]Path:[/bold] {wallet.path}")
+                console.print(
+                    f"[bold]SS58 Address:[/bold] [{COLORS.G.CK}]{keypair.ss58_address}[/{COLORS.G.CK}]"
+                )
+
+        except Exception as e:
+            error_msg = str(e)
+            if (
+                "not enough shares" in error_msg.lower()
+                or "threshold" in error_msg.lower()
+            ):
+                error_msg = (
+                    f"Not enough shares to recover the secret. "
+                    f"You provided {len(shares)} shares but more may be required."
+                )
+
+            if json_output:
+                console.print_json(
+                    data={"success": False, "error": error_msg, "data": None}
+                )
+            else:
+                err_console.print(
+                    f":cross_mark: [red]Failed to recover coldkey: {error_msg}[/red]"
+                )
+            raise typer.Exit(1)
 
     def wallet_check_ck_swap(
         self,

--- a/bittensor_cli/src/bittensor/slip39.py
+++ b/bittensor_cli/src/bittensor/slip39.py
@@ -1,0 +1,460 @@
+"""
+SLIP39 (Shamir's Secret Sharing) utilities for Bittensor wallet management.
+
+This module provides functionality to:
+1. Generate SLIP39 mnemonic shares from a seed/entropy
+2. Recover seed/entropy from SLIP39 mnemonic shares
+3. Create coldkeys with SLIP39 share output (no plaintext mnemonic exposure)
+4. Recover coldkeys from SLIP39 shares
+
+SLIP39 allows splitting a secret into N shares where M shares are required
+to reconstruct the original secret (M-of-N threshold scheme).
+
+References:
+- SLIP-0039: https://github.com/satoshilabs/slips/blob/master/slip-0039.md
+- shamir-mnemonic: https://github.com/trezor/python-shamir-mnemonic
+"""
+
+import os
+import secrets
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Union
+
+from bittensor_wallet import Keypair, Wallet
+from shamir_mnemonic import generate_mnemonics, combine_mnemonics
+from shamir_mnemonic.share import Share
+
+from bittensor_cli.src.bittensor.utils import console
+
+
+# Constants for entropy sizes (in bytes)
+ENTROPY_128_BITS = 16  # 12-word BIP39 mnemonic equivalent
+ENTROPY_256_BITS = 32  # 24-word BIP39 mnemonic equivalent
+
+
+@dataclass
+class SLIP39Config:
+    """Configuration for SLIP39 share generation."""
+
+    group_threshold: int = 1  # Number of groups required to recover
+    groups: list[tuple[int, int]] = None  # List of (threshold, count) per group
+    passphrase: str = ""  # Optional passphrase for additional security
+    iteration_exponent: int = (
+        1  # PBKDF2 iteration exponent (higher = slower but more secure)
+    )
+
+    def __post_init__(self):
+        if self.groups is None:
+            # Default: single group with 2-of-3 threshold
+            self.groups = [(2, 3)]
+
+    @property
+    def total_shares(self) -> int:
+        """Total number of shares across all groups."""
+        return sum(count for _, count in self.groups)
+
+    @property
+    def threshold_description(self) -> str:
+        """Human-readable description of the threshold scheme."""
+        if len(self.groups) == 1:
+            threshold, count = self.groups[0]
+            return f"{threshold}-of-{count}"
+        else:
+            group_descs = [f"{t}-of-{c}" for t, c in self.groups]
+            return (
+                f"{self.group_threshold} groups required from: {', '.join(group_descs)}"
+            )
+
+
+@dataclass
+class SLIP39ShareSet:
+    """Container for generated SLIP39 shares."""
+
+    shares: list[list[str]]  # Shares organized by group
+    config: SLIP39Config
+    identifier: int  # Share set identifier for matching shares
+
+    def all_shares_flat(self) -> list[str]:
+        """Return all shares as a flat list."""
+        return [share for group in self.shares for share in group]
+
+    def get_group(self, group_index: int) -> list[str]:
+        """Get shares for a specific group."""
+        if 0 <= group_index < len(self.shares):
+            return self.shares[group_index]
+        raise IndexError(f"Group index {group_index} out of range")
+
+
+def generate_slip39_shares(
+    master_secret: bytes,
+    config: Optional[SLIP39Config] = None,
+) -> SLIP39ShareSet:
+    """
+    Generate SLIP39 mnemonic shares from a master secret.
+
+    Args:
+        master_secret: The secret to split (16 or 32 bytes for 128/256-bit security)
+        config: SLIP39 configuration (threshold, groups, passphrase)
+
+    Returns:
+        SLIP39ShareSet containing the generated mnemonic shares
+
+    Raises:
+        ValueError: If master_secret length is invalid
+    """
+    if len(master_secret) not in (ENTROPY_128_BITS, ENTROPY_256_BITS):
+        raise ValueError(
+            f"Master secret must be {ENTROPY_128_BITS} or {ENTROPY_256_BITS} bytes, "
+            f"got {len(master_secret)}"
+        )
+
+    if config is None:
+        config = SLIP39Config()
+
+    # Generate SLIP39 mnemonics
+    mnemonics = generate_mnemonics(
+        group_threshold=config.group_threshold,
+        groups=config.groups,
+        master_secret=master_secret,
+        passphrase=config.passphrase.encode() if config.passphrase else b"",
+        iteration_exponent=config.iteration_exponent,
+    )
+
+    # Extract identifier from first share for reference
+    first_share = Share.from_mnemonic(mnemonics[0][0])
+    identifier = first_share.identifier
+
+    return SLIP39ShareSet(
+        shares=mnemonics,
+        config=config,
+        identifier=identifier,
+    )
+
+
+def recover_secret_from_shares(
+    shares: list[str],
+    passphrase: str = "",
+) -> bytes:
+    """
+    Recover the master secret from SLIP39 mnemonic shares.
+
+    Args:
+        shares: List of SLIP39 mnemonic strings (must meet threshold requirements)
+        passphrase: Optional passphrase used during share generation
+
+    Returns:
+        The recovered master secret as bytes
+
+    Raises:
+        ValueError: If shares are invalid or insufficient
+        MnemonicError: If shares cannot be combined
+    """
+    if not shares:
+        raise ValueError("No shares provided")
+
+    return combine_mnemonics(
+        shares,
+        passphrase=passphrase.encode() if passphrase else b"",
+    )
+
+
+def generate_secure_entropy(n_bytes: int = ENTROPY_256_BITS) -> bytes:
+    """
+    Generate cryptographically secure random entropy.
+
+    Args:
+        n_bytes: Number of bytes to generate (16 or 32)
+
+    Returns:
+        Random bytes suitable for use as a master secret
+    """
+    if n_bytes not in (ENTROPY_128_BITS, ENTROPY_256_BITS):
+        raise ValueError(f"n_bytes must be {ENTROPY_128_BITS} or {ENTROPY_256_BITS}")
+    return secrets.token_bytes(n_bytes)
+
+
+def entropy_to_keypair(entropy: bytes) -> Keypair:
+    """
+    Create a Keypair from entropy bytes.
+
+    This uses the entropy as a mini-secret to derive a keypair,
+    compatible with how BIP39 mnemonics work in substrate.
+
+    Args:
+        entropy: 16 or 32 bytes of entropy
+
+    Returns:
+        A Keypair derived from the entropy
+    """
+    # Use the entropy as a seed to create a keypair
+    # We pad to 32 bytes if needed (for 128-bit entropy)
+    if len(entropy) == ENTROPY_128_BITS:
+        # Pad with zeros to make 32 bytes for sr25519
+        seed = entropy + bytes(16)
+    else:
+        seed = entropy
+
+    return Keypair.create_from_seed(seed.hex())
+
+
+def create_coldkey_with_slip39(
+    wallet: Wallet,
+    config: Optional[SLIP39Config] = None,
+    use_password: bool = True,
+    overwrite: bool = False,
+    entropy_bits: int = 256,
+) -> tuple[SLIP39ShareSet, Keypair]:
+    """
+    Create a new coldkey and generate SLIP39 shares for backup.
+
+    The coldkey is created from secure random entropy, and SLIP39 shares
+    are generated for that entropy. The plaintext mnemonic is never exposed.
+
+    Args:
+        wallet: The wallet to create the coldkey for
+        config: SLIP39 configuration
+        use_password: Whether to encrypt the keyfile with a password
+        overwrite: Whether to overwrite existing coldkey
+        entropy_bits: Entropy size (128 or 256 bits)
+
+    Returns:
+        Tuple of (SLIP39ShareSet, Keypair) - the shares and the created keypair
+
+    Raises:
+        ValueError: If entropy_bits is invalid
+    """
+    if entropy_bits not in (128, 256):
+        raise ValueError("entropy_bits must be 128 or 256")
+
+    n_bytes = ENTROPY_128_BITS if entropy_bits == 128 else ENTROPY_256_BITS
+
+    # Generate secure entropy
+    entropy = generate_secure_entropy(n_bytes)
+
+    # Generate SLIP39 shares from entropy
+    share_set = generate_slip39_shares(entropy, config)
+
+    # Create keypair from entropy
+    keypair = entropy_to_keypair(entropy)
+
+    # Set the coldkey on the wallet
+    wallet.set_coldkey(keypair=keypair, encrypt=use_password, overwrite=overwrite)
+    wallet.set_coldkeypub(keypair=keypair, overwrite=overwrite)
+
+    # Clear entropy from memory (best effort)
+    entropy = b"\x00" * len(entropy)
+
+    return share_set, keypair
+
+
+def recover_coldkey_from_slip39(
+    wallet: Wallet,
+    shares: list[str],
+    passphrase: str = "",
+    use_password: bool = True,
+    overwrite: bool = False,
+) -> Keypair:
+    """
+    Recover a coldkey from SLIP39 mnemonic shares.
+
+    Args:
+        wallet: The wallet to recover the coldkey to
+        shares: List of SLIP39 mnemonic strings
+        passphrase: Optional passphrase used during share generation
+        use_password: Whether to encrypt the keyfile with a password
+        overwrite: Whether to overwrite existing coldkey
+
+    Returns:
+        The recovered Keypair
+
+    Raises:
+        ValueError: If shares are invalid
+        MnemonicError: If shares cannot be combined
+    """
+    # Recover entropy from shares
+    entropy = recover_secret_from_shares(shares, passphrase)
+
+    # Create keypair from recovered entropy
+    keypair = entropy_to_keypair(entropy)
+
+    # Set the coldkey on the wallet
+    wallet.set_coldkey(keypair=keypair, encrypt=use_password, overwrite=overwrite)
+    wallet.set_coldkeypub(keypair=keypair, overwrite=overwrite)
+
+    # Clear entropy from memory (best effort)
+    entropy = b"\x00" * len(entropy)
+
+    return keypair
+
+
+def save_shares_to_files(
+    share_set: SLIP39ShareSet,
+    output_dir: Union[str, Path],
+    prefix: str = "share",
+) -> list[Path]:
+    """
+    Save SLIP39 shares to individual files.
+
+    Each share is saved to a separate file for distribution to different
+    custodians or storage locations.
+
+    Args:
+        share_set: The SLIP39ShareSet to save
+        output_dir: Directory to save share files
+        prefix: Filename prefix for share files
+
+    Returns:
+        List of paths to created share files
+    """
+    output_dir = Path(output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    created_files = []
+    share_num = 1
+
+    for group_idx, group in enumerate(share_set.shares):
+        for share_idx, share in enumerate(group):
+            filename = f"{prefix}_g{group_idx + 1}_s{share_idx + 1}_{share_num}.slip39"
+            filepath = output_dir / filename
+
+            with open(filepath, "w") as f:
+                f.write(f"# SLIP39 Share {share_num}\n")
+                f.write(f"# Group {group_idx + 1}, Share {share_idx + 1}\n")
+                f.write(f"# Identifier: {share_set.identifier}\n")
+                f.write(f"# Threshold: {share_set.config.threshold_description}\n")
+                f.write("#\n")
+                f.write("# KEEP THIS FILE SECURE!\n")
+                f.write("# This share is required to recover your wallet.\n")
+                f.write("#\n")
+                f.write(share)
+                f.write("\n")
+
+            # Set restrictive permissions
+            os.chmod(filepath, 0o600)
+
+            created_files.append(filepath)
+            share_num += 1
+
+    return created_files
+
+
+def load_shares_from_files(file_paths: list[Union[str, Path]]) -> list[str]:
+    """
+    Load SLIP39 shares from files.
+
+    Args:
+        file_paths: List of paths to share files
+
+    Returns:
+        List of SLIP39 mnemonic strings
+    """
+    shares = []
+
+    for path in file_paths:
+        path = Path(path)
+        if not path.exists():
+            raise FileNotFoundError(f"Share file not found: {path}")
+
+        with open(path, "r") as f:
+            lines = f.readlines()
+
+        # Filter out comments and empty lines
+        share_lines = [
+            line.strip() for line in lines if line.strip() and not line.startswith("#")
+        ]
+
+        if share_lines:
+            shares.append(share_lines[0])
+
+    return shares
+
+
+def validate_shares(shares: list[str]) -> dict:
+    """
+    Validate SLIP39 shares and return information about them.
+
+    Args:
+        shares: List of SLIP39 mnemonic strings to validate
+
+    Returns:
+        Dictionary with validation results and share information
+    """
+    if not shares:
+        return {"valid": False, "error": "No shares provided"}
+
+    try:
+        parsed_shares = [Share.from_mnemonic(s) for s in shares]
+
+        # Check all shares have same identifier
+        identifiers = set(s.identifier for s in parsed_shares)
+        if len(identifiers) > 1:
+            return {
+                "valid": False,
+                "error": "Shares have different identifiers - they belong to different share sets",
+            }
+
+        # Get share information
+        first_share = parsed_shares[0]
+        group_indices = set(s.group_index for s in parsed_shares)
+
+        return {
+            "valid": True,
+            "identifier": first_share.identifier,
+            "share_count": len(shares),
+            "groups_represented": len(group_indices),
+            "group_threshold": first_share.group_threshold,
+            "iteration_exponent": first_share.iteration_exponent,
+        }
+
+    except Exception as e:
+        return {"valid": False, "error": str(e)}
+
+
+def print_shares_securely(
+    share_set: SLIP39ShareSet,
+    show_shares: bool = False,
+) -> None:
+    """
+    Print SLIP39 share information to console.
+
+    Args:
+        share_set: The SLIP39ShareSet to display
+        show_shares: If True, display the actual mnemonic shares (use with caution!)
+    """
+    console.print("\n[bold cyan]═══ SLIP39 Share Information ═══[/bold cyan]\n")
+    console.print(f"[bold]Identifier:[/bold] {share_set.identifier}")
+    console.print(f"[bold]Threshold:[/bold] {share_set.config.threshold_description}")
+    console.print(f"[bold]Total Shares:[/bold] {share_set.config.total_shares}")
+
+    if share_set.config.passphrase:
+        console.print("[bold yellow]⚠ Passphrase protection enabled[/bold yellow]")
+
+    console.print()
+
+    for group_idx, group in enumerate(share_set.shares):
+        console.print(f"[bold green]Group {group_idx + 1}:[/bold green]")
+        threshold, count = share_set.config.groups[group_idx]
+        console.print(f"  Threshold: {threshold} of {count} shares required")
+
+        for share_idx, share in enumerate(group):
+            if show_shares:
+                console.print(f"  [dim]Share {share_idx + 1}:[/dim]")
+                console.print(f"    [yellow]{share}[/yellow]")
+            else:
+                # Show only first few words as identifier
+                words = share.split()[:3]
+                console.print(
+                    f"  [dim]Share {share_idx + 1}:[/dim] {' '.join(words)}... "
+                    f"[dim]({len(share.split())} words)[/dim]"
+                )
+
+    console.print()
+    console.print(
+        "[bold red]⚠ IMPORTANT:[/bold red] Store these shares securely in separate locations!"
+    )
+    console.print(
+        "  Each share should be given to a different custodian or stored separately."
+    )
+    console.print("  Never store all shares together or in digital form on one device.")
+    console.print()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ dependencies = [
     "packaging",
     "plotille>=5.0.0",
     "plotly>=6.0.0",
+    "shamir-mnemonic>=0.3.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -1,3 +1,6 @@
+import tempfile
+from unittest.mock import AsyncMock, patch, MagicMock, Mock
+
 import numpy as np
 import pytest
 import typer
@@ -7,7 +10,19 @@ from bittensor_cli.src.bittensor.extrinsics.root import (
     get_current_weights_for_uid,
     set_root_weights_extrinsic,
 )
-from unittest.mock import AsyncMock, patch, MagicMock, Mock
+from bittensor_cli.src.bittensor.slip39 import (
+    SLIP39Config,
+    ENTROPY_256_BITS,
+    generate_slip39_shares,
+    recover_secret_from_shares,
+    generate_secure_entropy,
+    entropy_to_keypair,
+    create_coldkey_with_slip39,
+    recover_coldkey_from_slip39,
+    save_shares_to_files,
+    load_shares_from_files,
+    validate_shares,
+)
 
 
 def test_parse_mnemonic():
@@ -792,3 +807,142 @@ async def test_set_root_weights_skips_current_weights_without_prompt():
         )
 
         mock_get_current.assert_not_called()
+
+
+# =============================================================================
+# SLIP39 (Shamir's Secret Sharing) Tests
+# =============================================================================
+
+
+class TestSLIP39Config:
+    """Tests for SLIP39Config dataclass."""
+
+    def test_default_config(self):
+        config = SLIP39Config()
+        assert config.group_threshold == 1
+        assert config.groups == [(2, 3)]
+        assert config.passphrase == ""
+
+    def test_custom_config(self):
+        config = SLIP39Config(
+            group_threshold=2,
+            groups=[(2, 3), (3, 5)],
+            passphrase="test",
+        )
+        assert config.group_threshold == 2
+        assert config.total_shares == 8
+
+    def test_threshold_description(self):
+        config = SLIP39Config(groups=[(2, 3)])
+        assert config.threshold_description == "2-of-3"
+
+
+class TestSLIP39ShareGeneration:
+    """Tests for SLIP39 share generation and recovery."""
+
+    def test_generate_and_recover_shares(self):
+        """Test generating shares and recovering the secret."""
+        entropy = generate_secure_entropy(ENTROPY_256_BITS)
+        config = SLIP39Config(groups=[(2, 3)])
+        share_set = generate_slip39_shares(entropy, config)
+
+        assert len(share_set.shares[0]) == 3
+        assert share_set.identifier > 0
+
+        # Recover with threshold shares
+        recovered = recover_secret_from_shares(share_set.shares[0][:2])
+        assert recovered == entropy
+
+    def test_generate_shares_with_passphrase(self):
+        """Test shares with passphrase protection."""
+        entropy = generate_secure_entropy(ENTROPY_256_BITS)
+        config = SLIP39Config(groups=[(2, 3)], passphrase="secret")
+        share_set = generate_slip39_shares(entropy, config)
+
+        # Correct passphrase recovers original
+        recovered = recover_secret_from_shares(
+            share_set.shares[0][:2], passphrase="secret"
+        )
+        assert recovered == entropy
+
+        # Wrong passphrase gives different result
+        recovered_wrong = recover_secret_from_shares(
+            share_set.shares[0][:2], passphrase="wrong"
+        )
+        assert recovered_wrong != entropy
+
+    def test_entropy_to_keypair(self):
+        """Test creating keypair from entropy."""
+        entropy = generate_secure_entropy(ENTROPY_256_BITS)
+        keypair = entropy_to_keypair(entropy)
+        assert keypair.ss58_address is not None
+
+        # Same entropy = same keypair
+        keypair2 = entropy_to_keypair(entropy)
+        assert keypair.ss58_address == keypair2.ss58_address
+
+
+class TestSLIP39Validation:
+    """Tests for share validation."""
+
+    def test_validate_valid_shares(self):
+        entropy = generate_secure_entropy(ENTROPY_256_BITS)
+        share_set = generate_slip39_shares(entropy)
+        result = validate_shares(share_set.shares[0])
+        assert result["valid"] is True
+
+    def test_validate_empty_shares(self):
+        result = validate_shares([])
+        assert result["valid"] is False
+
+    def test_validate_mixed_identifiers(self):
+        """Shares from different sets should fail validation."""
+        entropy1 = generate_secure_entropy(ENTROPY_256_BITS)
+        entropy2 = generate_secure_entropy(ENTROPY_256_BITS)
+        share_set1 = generate_slip39_shares(entropy1)
+        share_set2 = generate_slip39_shares(entropy2)
+
+        mixed = [share_set1.shares[0][0], share_set2.shares[0][0]]
+        result = validate_shares(mixed)
+        assert result["valid"] is False
+
+
+class TestSLIP39FileOperations:
+    """Tests for file I/O operations."""
+
+    def test_save_and_load_shares(self):
+        entropy = generate_secure_entropy(ENTROPY_256_BITS)
+        share_set = generate_slip39_shares(entropy)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            files = save_shares_to_files(share_set, tmpdir)
+            assert len(files) == 3
+
+            loaded = load_shares_from_files(files[:2])
+            recovered = recover_secret_from_shares(loaded)
+            assert recovered == entropy
+
+
+class TestSLIP39ColdkeyOperations:
+    """Tests for coldkey creation and recovery."""
+
+    def test_create_and_recover_coldkey(self):
+        """Test full coldkey workflow with SLIP39."""
+        wallet = MagicMock()
+        config = SLIP39Config(groups=[(2, 3)])
+
+        share_set, keypair = create_coldkey_with_slip39(
+            wallet=wallet,
+            config=config,
+            use_password=False,
+        )
+
+        # Recover
+        wallet2 = MagicMock()
+        recovered_keypair = recover_coldkey_from_slip39(
+            wallet=wallet2,
+            shares=share_set.shares[0][:2],
+            use_password=False,
+        )
+
+        assert recovered_keypair.ss58_address == keypair.ss58_address


### PR DESCRIPTION
# Add SLIP39 (Shamir's Secret Sharing) Support for Coldkey Management

## Summary

This PR implements SLIP39 support for coldkey management, addressing issue #407. It allows users to create and recover coldkeys using Shamir's Secret Sharing, where the plaintext seed phrase is **never exposed** - eliminating the risk of screen reader and keylogger attacks.

Closes #407

## What's Changed

### New Commands

**Create a coldkey with SLIP39 shares:**
```bash
# Default 3-of-5 threshold scheme
btcli wallet new-coldkey-slip39

# Custom threshold (2-of-3)
btcli wallet new-coldkey-slip39 --shares 3 --threshold 2

# Save shares to files for distribution
btcli wallet new-coldkey-slip39 --output-dir /secure/location

# Add passphrase protection
btcli wallet new-coldkey-slip39 --passphrase "extra security"
```

**Recover a coldkey from shares:**
```bash
# From share files
btcli wallet recover-coldkey-slip39 -f share1.slip39 -f share2.slip39 -f share3.slip39

# Interactive mode (enter shares manually)
btcli wallet recover-coldkey-slip39

# With passphrase
btcli wallet recover-coldkey-slip39 -f share1.slip39 -f share2.slip39 --passphrase "extra security"
```

### How It Works

SLIP39 splits a secret into N shares where M shares are required to reconstruct the original (M-of-N threshold scheme). For example, with a 3-of-5 setup:
- 5 shares are generated, each as a 20-33 word mnemonic
- Any 3 shares can recover the original coldkey
- Losing up to 2 shares doesn't prevent recovery
- An attacker needs at least 3 shares to compromise the wallet

### Security Benefits

1. **No plaintext exposure**: The seed phrase is never displayed or entered - only SLIP39 shares are shown
2. **Distributed custody**: Shares can be given to different people or stored in separate locations
3. **Fault tolerance**: Losing some shares doesn't mean losing access (if threshold is met)
4. **Optional passphrase**: Additional layer of security that must be memorized

### Use Cases

- **Personal backup**: Keep shares in different physical locations (home, safe deposit box, trusted family)
- **Corporate treasury**: Distribute shares among executives - any 3 of 5 can authorize transactions
- **Team wallets**: No single person has full control; requires collaboration to access funds

## Files Changed

| File | Description |
|------|-------------|
| `bittensor_cli/src/bittensor/slip39.py` | Core SLIP39 utilities for share generation and recovery |
| `bittensor_cli/cli.py` | New CLI commands (`new-coldkey-slip39`, `recover-coldkey-slip39`) |
| `tests/unit_tests/test_cli.py` | 11 unit tests covering SLIP39 functionality |
| `pyproject.toml` | Added `shamir-mnemonic>=0.3.0` dependency |

## Testing

- Added 11 unit tests covering:
  - Configuration and threshold descriptions
  - Share generation and recovery
  - Passphrase protection (correct vs wrong passphrase)
  - Share validation (empty, invalid, mixed identifiers)
  - File I/O operations
  - Full coldkey create/recover workflow

All tests pass:
```
tests/unit_tests/test_cli.py::TestSLIP39Config::test_default_config PASSED
tests/unit_tests/test_cli.py::TestSLIP39Config::test_custom_config PASSED
tests/unit_tests/test_cli.py::TestSLIP39Config::test_threshold_description PASSED
tests/unit_tests/test_cli.py::TestSLIP39ShareGeneration::test_generate_and_recover_shares PASSED
tests/unit_tests/test_cli.py::TestSLIP39ShareGeneration::test_generate_shares_with_passphrase PASSED
tests/unit_tests/test_cli.py::TestSLIP39ShareGeneration::test_entropy_to_keypair PASSED
tests/unit_tests/test_cli.py::TestSLIP39Validation::test_validate_valid_shares PASSED
tests/unit_tests/test_cli.py::TestSLIP39Validation::test_validate_empty_shares PASSED
tests/unit_tests/test_cli.py::TestSLIP39Validation::test_validate_mixed_identifiers PASSED
tests/unit_tests/test_cli.py::TestSLIP39FileOperations::test_save_and_load_shares PASSED
tests/unit_tests/test_cli.py::TestSLIP39ColdkeyOperations::test_create_and_recover_coldkey PASSED
```

## Dependencies

Added `shamir-mnemonic>=0.3.0` - the official Trezor implementation of SLIP39.

## References

- Issue: #407
- SLIP-0039 Specification: https://github.com/satoshilabs/slips/blob/master/slip-0039.md
- shamir-mnemonic library: https://github.com/trezor/python-shamir-mnemonic

## Checklist

- [x] Forked from `staging` branch
- [x] Added tests for new functionality
- [x] All tests pass
- [x] Code lints cleanly (ruff)
- [x] Detailed explanation provided
