### PR TITLE
fix: expose confirmed hidden commands (weights, subnets metagraph, e.t.c)

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -923,7 +923,6 @@ class CLIManager:
             self.weights_app,
             name="weights",
             short_help="Weights commands, aliases: `wt`, `weight`",
-            hidden=True,
             no_args_is_help=True,
         )
         self.app.add_typer(
@@ -1149,7 +1148,7 @@ class CLIManager:
             "register", rich_help_panel=HELP_PANELS["SUBNETS"]["REGISTER"]
         )(self.subnets_register)
         self.subnets_app.command(
-            "metagraph", rich_help_panel=HELP_PANELS["SUBNETS"]["INFO"], hidden=True
+            "metagraph", rich_help_panel=HELP_PANELS["SUBNETS"]["INFO"]
         )(self.subnets_show)  # Aliased to `s show` for now
         self.subnets_app.command(
             "show", rich_help_panel=HELP_PANELS["SUBNETS"]["INFO"]
@@ -1266,11 +1265,9 @@ class CLIManager:
         # Stake
         self.stake_app.command(
             "claim",
-            hidden=True,
         )(self.stake_set_claim_type)
         self.stake_app.command(
             "unclaim",
-            hidden=True,
         )(self.stake_set_claim_type)
 
         # Crowdloan


### PR DESCRIPTION
## Why This Change Helps

Before this change, `btcli --commands` only showed a **subset of the commands that actually work**. Several user-facing and functional commands were hidden due to `hidden=True` in their Typer registrations, even though they were stable and usable.

This created a discoverability gap:
- Users reasonably assumed `btcli --commands` was the authoritative list of supported commands.
- Important functionality (like weights commit/reveal, stake claim/unclaim, and subnet metagraph) was effectively invisible unless learned from external sources or by reading the code.
- This reinforced confusion, tribal knowledge, and misinformation, especially for newer users.

### What This Change Does

This change **does not add new features** and **does not modify behavior**.

It simply:
- Removes `hidden=True` from a small, confirmed set of working commands.
- Makes `btcli --commands` accurately reflect what users can actually do with the CLI.

Specifically, it exposes:
- The `weights` command group (commit and reveal)
- `subnets metagraph`, which surfaces critical subnet information like registration cost
- `stake claim` and `stake unclaim`, which are valid alternatives to the set-claim flow

### What This Change Does NOT Do

- It does not expose broken or incomplete commands (`wallet history`, `wallet inspect` remain hidden).
- It does not expose legacy aliases or namespace shortcuts.
- It does not change command logic, execution paths, or protocol behavior.


Contribution by Gittensor, learn more at https://gittensor.io/
