### PR TITLE
Fix live display formatting on macOS Terminal.app

### DIFF
--- a/bittensor_cli/src/commands/stake/list.py
+++ b/bittensor_cli/src/commands/stake/list.py
@@ -539,7 +539,7 @@ async def stake_list(
         current_block = None
         previous_data = None
 
-        with Live(console=console, screen=True, auto_refresh=True) as live:
+        with Live(console=console, auto_refresh=True) as live:
             try:
                 while True:
                     block_hash = await subtensor.substrate.get_chain_head()

--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -933,7 +933,7 @@ async def subnets_list(
         current_block = None
         previous_data = None
 
-        with Live(console=console, screen=True, auto_refresh=True) as live:
+        with Live(console=console, auto_refresh=True) as live:
             try:
                 while True:
                     (


### PR DESCRIPTION
## Summary

This PR fixes the live display formatting issues on macOS's stock Terminal.app for the `subnets list --live` and `stake list --live` commands.

### Problem

The `--live` flag for `btcli subnets list` and `btcli stake list` commands uses Rich's `Live` component with `screen=True`, which enables alternate screen buffer mode. However, macOS's native Terminal.app has known compatibility issues with alternate screen buffer rendering, causing visual corruption and misaligned output.

More capable terminals like iTerm2 handle this correctly, but users on the stock Terminal.app experience broken formatting.

### Changes

**File: `bittensor_cli/src/commands/subnets/subnets.py`**

1. **Removed `screen=True` parameter** from the `Live` context manager
   - The live display now renders inline instead of using alternate screen buffer

**File: `bittensor_cli/src/commands/stake/list.py`**

1. **Removed `screen=True` parameter** from the `Live` context manager
   - Consistent fix applied to stake list live mode

### Before & After

**Before (macOS Terminal.app):**
<img width="1799" height="951" alt="image" src="https://github.com/user-attachments/assets/07a7b7ba-77b1-4c65-9c72-8ef84aef55b9" />

**After (macOS Terminal.app):**
<img width="1799" height="951" alt="image" src="https://github.com/user-attachments/assets/9bb3a3c8-39ff-452c-a4ec-52f46c941387" />

Fixes #315

---

Contribution by Gittensor, learn more at https://gittensor.io/