### PR TITLE
fix: disable wallet history command due to external API deprecation

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -3841,8 +3841,10 @@ class CLIManager:
         #     if self.config.get("network") != "finney":
         #         console.print(no_use_config_str)
 
-        # For Rao games
-        print_error("This command is disabled on the 'rao' network.")
+        print_error(
+            "This command is currently disabled as it used external APIs which are no longer "
+            "feasible; meanwhile a chain native data fetching solution is being investigated."
+        )
         raise typer.Exit()
 
         self.verbosity_handler(quiet, verbose, False, False)


### PR DESCRIPTION
## Summary

- Disables the `wallet history` command with an informative error message
- The Taostats API this command relied on is no longer feasible (requires API key)
- A chain-native data fetching solution is being investigated

## Related Issues

- Fixes #235
- Related to #302

## Reviewers

@thewhaleking @distributedstatemachine @ibraheem-abe