### PR TITLE
docs: fix typo in README (pacakge → package)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ You can install `btcli` on your local machine directly from source, PyPI, or Hom
 Note that the macOS preinstalled CPython installation is compiled with LibreSSL instead of OpenSSL. There are a number
 of issues with LibreSSL, and as such is not fully supported by the libraries used by btcli. Thus we highly recommend, if 
 you are using a Mac, to first install Python from [Homebrew](https://brew.sh/). Additionally, the Rust FFI bindings 
-[if installing from precompiled wheels (default)] require the Homebrew-installed OpenSSL pacakge. If you choose to use
+[if installing from precompiled wheels (default)] require the Homebrew-installed OpenSSL package. If you choose to use
 the preinstalled Python version from macOS, things may not work completely.
 
 


### PR DESCRIPTION
Fix typo in macOS installation notes.