### PR TITLE
Add better typing

### DIFF
--- a/bittensor_cli/src/bittensor/chain_data.py
+++ b/bittensor_cli/src/bittensor/chain_data.py
@@ -3,7 +3,6 @@ from dataclasses import dataclass
 from collections.abc import Sequence
 from enum import Enum
 from typing import Optional, Any, Union, Callable, Hashable
-from typing_extensions import Self
 
 import netaddr
 from scalecodec.utils.ss58 import ss58_encode
@@ -17,6 +16,11 @@ from bittensor_cli.src.bittensor.utils import (
     decode_account_id,
     get_netuid_and_subuid_by_storage_index,
 )
+
+try:
+    from typing import Self
+except ImportError:
+    from typing_extensions import Self
 
 
 class ChainDataType(Enum):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dependencies = [
     "rich>=13.7,<15.0",
     "scalecodec==1.2.12",
     "typer>=0.16",
-    "typing_extensions>4.0.0",
+    "typing_extensions>4.0.0; python_version<'3.11'",
     "bittensor-wallet>=4.0.0",
     "packaging",
     "plotille>=5.0.0",


### PR DESCRIPTION
Fixes some annoying mypy messages. Uses typing extensions because `typing.Self` was only added in Python 3.11