### PR TITLE
ASI version <2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "wheel",
-    "async-substrate-interface>=1.6.2",
+    "async-substrate-interface>=1.6.2,<2.0.0",
     "aiohttp~=3.13",
     "backoff~=2.2.1",
     "bittensor-drand>=1.3.0",


### PR DESCRIPTION
With the upcoming release of ASI 2.0 (probably in a month or two), we want to ensure users of old versions don't accidentally bump use an incompatible version.