### PR TITLE
fix: resolve proxy address for stake queries in move/transfer/swap and sudo trim

### DIFF
--- a/bittensor_cli/src/commands/stake/move.py
+++ b/bittensor_cli/src/commands/stake/move.py
@@ -540,6 +540,7 @@ async def move_stake(
     proxy: Optional[str] = None,
     mev_protection: bool = True,
 ) -> tuple[bool, str]:
+    coldkey_ss58 = proxy or wallet.coldkeypub.ss58_address
     if interactive_selection:
         try:
             selection = await stake_move_transfer_selection(subtensor, wallet)
@@ -553,16 +554,15 @@ async def move_stake(
 
     # Get the wallet stake balances.
     block_hash = await subtensor.substrate.get_chain_head()
-    # TODO should this use `proxy if proxy else wallet.coldkeypub.ss58_address`?
     origin_stake_balance, destination_stake_balance = await asyncio.gather(
         subtensor.get_stake(
-            coldkey_ss58=wallet.coldkeypub.ss58_address,
+            coldkey_ss58=coldkey_ss58,
             hotkey_ss58=origin_hotkey,
             netuid=origin_netuid,
             block_hash=block_hash,
         ),
         subtensor.get_stake(
-            coldkey_ss58=wallet.coldkeypub.ss58_address,
+            coldkey_ss58=coldkey_ss58,
             hotkey_ss58=destination_hotkey,
             netuid=destination_netuid,
             block_hash=block_hash,
@@ -705,13 +705,13 @@ async def move_stake(
                 new_destination_stake_balance,
             ) = await asyncio.gather(
                 subtensor.get_stake(
-                    coldkey_ss58=wallet.coldkeypub.ss58_address,
+                    coldkey_ss58=coldkey_ss58,
                     hotkey_ss58=origin_hotkey,
                     netuid=origin_netuid,
                     block_hash=block_hash,
                 ),
                 subtensor.get_stake(
-                    coldkey_ss58=wallet.coldkeypub.ss58_address,
+                    coldkey_ss58=coldkey_ss58,
                     hotkey_ss58=destination_hotkey,
                     netuid=destination_netuid,
                     block_hash=block_hash,
@@ -771,6 +771,7 @@ async def transfer_stake(
             bool: True if transfer was successful, False otherwise.
             str: error message
     """
+    coldkey_ss58 = proxy or wallet.coldkeypub.ss58_address
     if interactive_selection:
         selection = await stake_move_transfer_selection(subtensor, wallet)
         origin_netuid = selection["origin_netuid"]
@@ -795,9 +796,8 @@ async def transfer_stake(
 
     # Get current stake balances
     with console.status(f"Retrieving stake data from {subtensor.network}..."):
-        # TODO should use proxy for these checks?
         current_stake = await subtensor.get_stake(
-            coldkey_ss58=wallet.coldkeypub.ss58_address,
+            coldkey_ss58=coldkey_ss58,
             hotkey_ss58=origin_hotkey,
             netuid=origin_netuid,
         )
@@ -918,7 +918,7 @@ async def transfer_stake(
                 # Get and display new stake balances
                 new_stake, new_dest_stake = await asyncio.gather(
                     subtensor.get_stake(
-                        coldkey_ss58=wallet.coldkeypub.ss58_address,
+                        coldkey_ss58=coldkey_ss58,
                         hotkey_ss58=origin_hotkey,
                         netuid=origin_netuid,
                     ),
@@ -989,6 +989,7 @@ async def swap_stake(
             success is True if the swap was successful, False otherwise.
             extrinsic_identifier if the extrinsic was successfully included
     """
+    coldkey_ss58 = proxy or wallet.coldkeypub.ss58_address
     hotkey_ss58 = get_hotkey_pub_ss58(wallet)
     if interactive_selection:
         try:
@@ -1016,12 +1017,12 @@ async def swap_stake(
     # Get current stake balances
     with console.status(f"Retrieving stake data from {subtensor.network}..."):
         current_stake = await subtensor.get_stake(
-            coldkey_ss58=wallet.coldkeypub.ss58_address,
+            coldkey_ss58=coldkey_ss58,
             hotkey_ss58=hotkey_ss58,
             netuid=origin_netuid,
         )
         current_dest_stake = await subtensor.get_stake(
-            coldkey_ss58=wallet.coldkeypub.ss58_address,
+            coldkey_ss58=coldkey_ss58,
             hotkey_ss58=hotkey_ss58,
             netuid=destination_netuid,
         )
@@ -1153,12 +1154,12 @@ async def swap_stake(
                 # Get and display new stake balances
                 new_stake, new_dest_stake = await asyncio.gather(
                     subtensor.get_stake(
-                        coldkey_ss58=wallet.coldkeypub.ss58_address,
+                        coldkey_ss58=coldkey_ss58,
                         hotkey_ss58=hotkey_ss58,
                         netuid=origin_netuid,
                     ),
                     subtensor.get_stake(
-                        coldkey_ss58=wallet.coldkeypub.ss58_address,
+                        coldkey_ss58=coldkey_ss58,
                         hotkey_ss58=hotkey_ss58,
                         netuid=destination_netuid,
                     ),

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -1481,14 +1481,14 @@ async def trim(
     """
     Trims a subnet's UIDs to a specified amount
     """
+    coldkey_ss58 = proxy or wallet.coldkeypub.ss58_address
     print_verbose("Confirming subnet owner")
     subnet_owner = await subtensor.query(
         module="SubtensorModule",
         storage_function="SubnetOwner",
         params=[netuid],
     )
-    # TODO should this check proxy also?
-    if subnet_owner != wallet.coldkeypub.ss58_address:
+    if subnet_owner != coldkey_ss58:
         err_msg = "This wallet doesn't own the specified subnet."
         if json_output:
             json_console.print_json(data={"success": False, "message": err_msg})

--- a/tests/unit_tests/test_proxy_address_resolution.py
+++ b/tests/unit_tests/test_proxy_address_resolution.py
@@ -1,0 +1,139 @@
+"""Tests for proxy address resolution in stake move/transfer/swap and sudo trim.
+
+When a proxy is active, chain queries (get_stake, SubnetOwner) must use the
+proxied account address, not the signer's address.
+"""
+
+import pytest
+from contextlib import contextmanager
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bittensor_cli.src.bittensor.balances import Balance
+
+SIGNER_SS58 = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+PROXY_SS58 = "5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY"
+HOTKEY_SS58 = "5CiQ1cV1MmMwsep7YP37QZKEgBgaVXeSPnETB5JBgwYRoXbP"
+DEST_HOTKEY_SS58 = "5DAAnrj7VHTznn2AWBemMuyBwZWs6FNFjdyVXUeYum3PTXFy"
+
+
+def _mock_wallet():
+    wallet = MagicMock()
+    wallet.coldkeypub.ss58_address = SIGNER_SS58
+    wallet.hotkey.ss58_address = HOTKEY_SS58
+    wallet.hotkey_str = "default"
+    return wallet
+
+
+def _mock_subtensor(stake_balance=Balance.from_tao(100)):
+    receipt = AsyncMock()
+    receipt.get_extrinsic_identifier = AsyncMock(return_value="0x123-1")
+    receipt.is_success = True
+    subtensor = MagicMock()
+    subtensor.network = "finney"
+    subtensor.substrate = MagicMock()
+    subtensor.substrate.get_chain_head = AsyncMock(return_value="0xabc")
+    subtensor.substrate.compose_call = AsyncMock(return_value=MagicMock())
+    subtensor.get_stake = AsyncMock(return_value=stake_balance)
+    subtensor.get_balance = AsyncMock(return_value=Balance.from_tao(500))
+    subtensor.subnet_exists = AsyncMock(return_value=True)
+    subtensor.get_extrinsic_fee = AsyncMock(return_value=Balance.from_tao(0.001))
+    subtensor.substrate.get_account_next_index = AsyncMock(return_value=0)
+    subtensor.sim_swap = AsyncMock(
+        return_value=MagicMock(alpha_amount=100, tao_fee=1, alpha_fee=1)
+    )
+    subtensor.sign_and_send_extrinsic = AsyncMock(return_value=(True, "", receipt))
+    subtensor.query = AsyncMock()
+    return subtensor
+
+
+@contextmanager
+def _move_patches(**extra):
+    base = "bittensor_cli.src.commands.stake.move"
+    with (
+        patch(
+            f"{base}.get_movement_pricing",
+            new_callable=AsyncMock,
+            return_value=MagicMock(rate_with_tolerance=None),
+        ),
+        patch(f"{base}.unlock_key", return_value=MagicMock(success=True)),
+        patch(f"{base}.print_extrinsic_id", new_callable=AsyncMock),
+    ):
+        if "hotkey" in extra:
+            with patch(f"{base}.get_hotkey_pub_ss58", return_value=extra["hotkey"]):
+                yield
+        else:
+            yield
+
+
+@pytest.mark.asyncio
+async def test_move_stake_uses_proxy_for_stake_lookup():
+    """move_stake must query stake using the proxied account address."""
+    from bittensor_cli.src.commands.stake.move import move_stake
+
+    subtensor = _mock_subtensor()
+    with _move_patches():
+        await move_stake(
+            subtensor=subtensor,
+            wallet=_mock_wallet(),
+            origin_netuid=1,
+            origin_hotkey=HOTKEY_SS58,
+            destination_netuid=2,
+            destination_hotkey=DEST_HOTKEY_SS58,
+            amount=10.0,
+            stake_all=False,
+            era=3,
+            prompt=False,
+            proxy=PROXY_SS58,
+            mev_protection=False,
+        )
+    for call in subtensor.get_stake.call_args_list:
+        assert call.kwargs["coldkey_ss58"] == PROXY_SS58
+
+
+@pytest.mark.asyncio
+async def test_trim_allows_proxy_owner():
+    """trim must accept the proxied account as subnet owner."""
+    from bittensor_cli.src.commands.sudo import trim
+
+    subtensor = _mock_subtensor()
+    subtensor.query = AsyncMock(return_value=PROXY_SS58)
+    base = "bittensor_cli.src.commands.sudo"
+    with (
+        patch(f"{base}.unlock_key", return_value=MagicMock(success=True)),
+        patch(f"{base}.print_extrinsic_id", new_callable=AsyncMock),
+    ):
+        result = await trim(
+            wallet=_mock_wallet(),
+            subtensor=subtensor,
+            netuid=1,
+            proxy=PROXY_SS58,
+            max_n=100,
+            period=100,
+            prompt=False,
+            decline=False,
+            quiet=True,
+            json_output=False,
+        )
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_trim_rejects_non_owner_with_proxy():
+    """trim must reject when the proxy doesn't own the subnet."""
+    from bittensor_cli.src.commands.sudo import trim
+
+    subtensor = _mock_subtensor()
+    subtensor.query = AsyncMock(return_value="5UNRELATED_ADDRESS")
+    result = await trim(
+        wallet=_mock_wallet(),
+        subtensor=subtensor,
+        netuid=1,
+        proxy=PROXY_SS58,
+        max_n=100,
+        period=100,
+        prompt=False,
+        decline=False,
+        quiet=True,
+        json_output=False,
+    )
+    assert result is False


### PR DESCRIPTION
[move_stake](cci:1://file:///root/74/gold/btcli/bittensor_cli/src/commands/stake/move.py:525:0-731:24), [transfer_stake](cci:1://file:///root/74/gold/btcli/bittensor_cli/src/commands/stake/move.py:734:0-943:28), [swap_stake](cci:1://file:///root/74/gold/btcli/bittensor_cli/src/commands/stake/move.py:946:0-1179:28) and [trim](cci:1://file:///root/74/gold/btcli/bittensor_cli/src/commands/sudo.py:1468:0-1535:19) use `wallet.coldkeypub.ss58_address` for `get_stake()`/ownership queries instead of resolving through proxy. Proxy users get zero-balance errors on valid operations.

Adds `coldkey_ss58 = proxy or wallet.coldkeypub.ss58_address` at the top of each function, matching the pattern in [stake/add.py](cci:7://file:///root/74/gold/btcli/bittensor_cli/src/commands/stake/add.py:0:0-0:0) and [stake/remove.py](cci:7://file:///root/74/gold/btcli/bittensor_cli/src/commands/stake/remove.py:0:0-0:0).