### PR TITLE
unstake: format error message incorrect

### DIFF
--- a/bittensor_cli/src/commands/stake/remove.py
+++ b/bittensor_cli/src/commands/stake/remove.py
@@ -864,10 +864,7 @@ async def _unstake_extrinsic(
         )
         return True, response
     else:
-        err_out(
-            f"{failure_prelude} with error: "
-            f"{format_error_message(await response.error_message)}"
-        )
+        err_out(f"{failure_prelude} with error: {err_msg}")
         return False, None
 
 


### PR DESCRIPTION
When `_unstake_extrinsic` changed to use `subtensor.sign_and_send_extrinsic`, which outputs a tuple of `(success, err_msg, response)`, we were still using the old logic which would attempt to pull the error message from the response, but in cases of failure, we should be using the `err_msg` rather than `await response.error_message`, as this is now `None` type.