### PR TITLE
fix: `stake add` operation mapping for multi-hotkey and multi-netuid

### DIFF
--- a/bittensor_cli/src/commands/stake/add.py
+++ b/bittensor_cli/src/commands/stake/add.py
@@ -339,13 +339,7 @@ async def stake_add(
             )
 
     # Determine the amount we are staking.
-    rows = []
-    amounts_to_stake = []
-    current_stake_balances = []
-    prices_with_tolerance = []
-    remaining_wallet_balance = current_wallet_balance
-    max_slippage = 0.0
-
+    operation_targets = []
     for hotkey in hotkeys_to_stake_to:
         for netuid in netuids:
             # Check that the subnet exists.
@@ -353,105 +347,126 @@ async def stake_add(
             if not subnet_info:
                 print_error(f"Subnet with netuid: {netuid} does not exist.")
                 continue
-            current_stake_balances.append(hotkey_stake_map[hotkey[1]][netuid])
+            operation_targets.append(
+                (hotkey, netuid, subnet_info, hotkey_stake_map[hotkey[1]][netuid])
+            )
 
-            # Get the amount.
-            amount_to_stake = Balance(0)
-            if amount:
-                amount_to_stake = Balance.from_tao(amount)
-            elif stake_all:
-                amount_to_stake = current_wallet_balance / len(netuids)
-            elif not amount:
-                amount_to_stake, _ = _prompt_stake_amount(
-                    current_balance=remaining_wallet_balance,
-                    netuid=netuid,
-                    action_name="stake",
-                )
-            amounts_to_stake.append(amount_to_stake)
+    if stake_all and not operation_targets:
+        print_error("No valid staking operations to perform.")
+        return
 
-            # Check enough to stake.
-            if amount_to_stake > remaining_wallet_balance:
-                print_error(
-                    f"Not enough stake:[bold white]\n wallet balance:{remaining_wallet_balance} < "
-                    f"staking amount: {amount_to_stake}[/bold white]"
-                )
-                return
-            remaining_wallet_balance -= amount_to_stake
+    rows = []
+    operations = []
+    remaining_wallet_balance = current_wallet_balance
+    max_slippage = 0.0
 
-            # Calculate slippage
-            # TODO: Update for V3, slippage calculation is significantly different in v3
-            # try:
-            #     received_amount, slippage_pct, slippage_pct_float, rate = (
-            #         _calculate_slippage(subnet_info, amount_to_stake, stake_fee)
-            #     )
-            # except ValueError:
-            #     return False
-            #
-            # max_slippage = max(slippage_pct_float, max_slippage)
+    for hotkey, netuid, subnet_info, current_stake_balance in operation_targets:
+        staking_address = hotkey[1]
 
-            # Temporary workaround - calculations without slippage
-            current_price_float = float(subnet_info.price.tao)
-            rate = _safe_inverse_rate(current_price_float)
+        # Get the amount.
+        amount_to_stake = Balance(0)
+        if amount:
+            amount_to_stake = Balance.from_tao(amount)
+        elif stake_all:
+            amount_to_stake = current_wallet_balance / len(operation_targets)
+        elif not amount:
+            amount_to_stake, _ = _prompt_stake_amount(
+                current_balance=remaining_wallet_balance,
+                netuid=netuid,
+                action_name="stake",
+            )
 
-            # If we are staking safe, add price tolerance
-            if safe_staking:
-                if subnet_info.is_dynamic:
-                    price_with_tolerance = current_price_float * (1 + rate_tolerance)
-                    _rate_with_tolerance = _safe_inverse_rate(
-                        price_with_tolerance
-                    )  # Rate only for display
-                    rate_with_tolerance = f"{_rate_with_tolerance:.4f}"
-                    price_with_tolerance = Balance.from_tao(
-                        price_with_tolerance
-                    )  # Actual price to pass to extrinsic
-                else:
-                    rate_with_tolerance = "1"
-                    price_with_tolerance = Balance.from_rao(1)
-                extrinsic_fee = await get_stake_extrinsic_fee(
-                    netuid_=netuid,
-                    amount_=amount_to_stake,
-                    staking_address_=hotkey[1],
-                    safe_staking_=safe_staking,
-                    price_limit=price_with_tolerance,
-                )
-                prices_with_tolerance.append(price_with_tolerance)
-                row_extension = [
-                    f"{rate_with_tolerance} {Balance.get_unit(netuid)}/{Balance.get_unit(0)} ",
-                    f"[{'dark_sea_green3' if allow_partial_stake else 'red'}]"
-                    # safe staking
-                    f"{allow_partial_stake}[/{'dark_sea_green3' if allow_partial_stake else 'red'}]",
-                ]
+        # Check enough to stake.
+        if amount_to_stake > remaining_wallet_balance:
+            print_error(
+                f"Not enough stake:[bold white]\n wallet balance:{remaining_wallet_balance} < "
+                f"staking amount: {amount_to_stake}[/bold white]"
+            )
+            return
+        remaining_wallet_balance -= amount_to_stake
+
+        # Calculate slippage
+        # TODO: Update for V3, slippage calculation is significantly different in v3
+        # try:
+        #     received_amount, slippage_pct, slippage_pct_float, rate = (
+        #         _calculate_slippage(subnet_info, amount_to_stake, stake_fee)
+        #     )
+        # except ValueError:
+        #     return False
+        #
+        # max_slippage = max(slippage_pct_float, max_slippage)
+
+        # Temporary workaround - calculations without slippage
+        current_price_float = float(subnet_info.price.tao)
+        rate = _safe_inverse_rate(current_price_float)
+        price_with_tolerance = None
+
+        # If we are staking safe, add price tolerance
+        if safe_staking:
+            if subnet_info.is_dynamic:
+                price_with_tolerance = current_price_float * (1 + rate_tolerance)
+                _rate_with_tolerance = _safe_inverse_rate(
+                    price_with_tolerance
+                )  # Rate only for display
+                rate_with_tolerance = f"{_rate_with_tolerance:.4f}"
+                price_with_tolerance = Balance.from_tao(
+                    price_with_tolerance
+                )  # Actual price to pass to extrinsic
             else:
-                extrinsic_fee = await get_stake_extrinsic_fee(
-                    netuid_=netuid,
-                    amount_=amount_to_stake,
-                    staking_address_=hotkey[1],
-                    safe_staking_=safe_staking,
-                )
-                row_extension = []
-            # TODO this should be asyncio gathered before the for loop
-            amount_minus_fee = (
-                (amount_to_stake - extrinsic_fee) if not proxy else amount_to_stake
+                rate_with_tolerance = "1"
+                price_with_tolerance = Balance.from_rao(1)
+            extrinsic_fee = await get_stake_extrinsic_fee(
+                netuid_=netuid,
+                amount_=amount_to_stake,
+                staking_address_=staking_address,
+                safe_staking_=safe_staking,
+                price_limit=price_with_tolerance,
             )
-            sim_swap = await subtensor.sim_swap(
-                origin_netuid=0,
-                destination_netuid=netuid,
-                amount=amount_minus_fee.rao,
+            row_extension = [
+                f"{rate_with_tolerance} {Balance.get_unit(netuid)}/{Balance.get_unit(0)} ",
+                f"[{'dark_sea_green3' if allow_partial_stake else 'red'}]"
+                # safe staking
+                f"{allow_partial_stake}[/{'dark_sea_green3' if allow_partial_stake else 'red'}]",
+            ]
+        else:
+            extrinsic_fee = await get_stake_extrinsic_fee(
+                netuid_=netuid,
+                amount_=amount_to_stake,
+                staking_address_=staking_address,
+                safe_staking_=safe_staking,
             )
-            received_amount = sim_swap.alpha_amount
-            # Add rows for the table
-            base_row = [
-                str(netuid),  # netuid
-                f"{hotkey[1]}",  # hotkey
-                str(amount_to_stake),  # amount
-                str(rate)
-                + f" {Balance.get_unit(netuid)}/{Balance.get_unit(0)} ",  # rate
-                str(received_amount.set_unit(netuid)),  # received
-                str(sim_swap.tao_fee),  # fee
-                str(extrinsic_fee),
-                # str(slippage_pct),  # slippage
-            ] + row_extension
-            rows.append(tuple(base_row))
+            row_extension = []
+        # TODO this should be asyncio gathered before the for loop
+        amount_minus_fee = (
+            (amount_to_stake - extrinsic_fee) if not proxy else amount_to_stake
+        )
+        sim_swap = await subtensor.sim_swap(
+            origin_netuid=0,
+            destination_netuid=netuid,
+            amount=amount_minus_fee.rao,
+        )
+        received_amount = sim_swap.alpha_amount
+        # Add rows for the table
+        base_row = [
+            str(netuid),  # netuid
+            f"{staking_address}",  # hotkey
+            str(amount_to_stake),  # amount
+            str(rate) + f" {Balance.get_unit(netuid)}/{Balance.get_unit(0)} ",  # rate
+            str(received_amount.set_unit(netuid)),  # received
+            str(sim_swap.tao_fee),  # fee
+            str(extrinsic_fee),
+            # str(slippage_pct),  # slippage
+        ] + row_extension
+        rows.append(tuple(base_row))
+        operations.append(
+            (
+                netuid,
+                staking_address,
+                amount_to_stake,
+                current_stake_balance,
+                price_with_tolerance,
+            )
+        )
 
     # Define and print stake table + slippage warning
     table = _define_stake_table(wallet, subtensor, safe_staking, rate_tolerance)
@@ -466,23 +481,6 @@ async def stake_add(
             return
     if not unlock_key(wallet).success:
         return
-
-    # Build the list of (netuid, hotkey, amount, current_stake, price_limit) tuples
-    # that describe each staking operation we need to perform.
-    # The zip aligns netuids with amounts/balances (which are populated per
-    # hotkey-netuid pair, but the zip truncates to len(netuids), matching the
-    # original execution order). Each netuid's amount/price applies to all hotkeys.
-    operations = []
-    if safe_staking:
-        for ni, am, curr, price in zip(
-            netuids, amounts_to_stake, current_stake_balances, prices_with_tolerance
-        ):
-            for _, staking_address in hotkeys_to_stake_to:
-                operations.append((ni, staking_address, am, curr, price))
-    else:
-        for ni, am, curr in zip(netuids, amounts_to_stake, current_stake_balances):
-            for _, staking_address in hotkeys_to_stake_to:
-                operations.append((ni, staking_address, am, curr, None))
 
     total_ops = len(operations)
     use_batch = total_ops > 1

--- a/tests/unit_tests/test_stake_add.py
+++ b/tests/unit_tests/test_stake_add.py
@@ -1,12 +1,15 @@
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from bittensor_cli.src.bittensor.balances import Balance
 from bittensor_cli.src.commands.stake.add import stake_add
 
-from tests.unit_tests.conftest import COLDKEY_SS58 as TEST_SS58
+from tests.unit_tests.conftest import (
+    ALT_HOTKEY_SS58,
+    COLDKEY_SS58 as TEST_SS58,
+)
 
 
 class MockSubnetInfo:
@@ -105,3 +108,138 @@ async def test_stake_add_mixed_prices_including_zero_does_not_raise(
 
     assert mock_subtensor.substrate.compose_call.await_count == 2
     assert mock_subtensor.sim_swap.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_stake_add_multi_hotkey_multi_netuid_preserves_operation_mapping(
+    mock_wallet,
+    mock_subtensor,
+):
+    mock_subtensor.sim_swap = _sim_swap_side_effect()
+    mock_subtensor.all_subnets.return_value = [
+        MockSubnetInfo(netuid=427, price_tao=1.5),
+        MockSubnetInfo(netuid=1, price_tao=2.0),
+    ]
+    mock_subtensor.sign_and_send_batch_extrinsic = AsyncMock(
+        return_value=(
+            True,
+            "",
+            MagicMock(get_extrinsic_identifier=AsyncMock(return_value="0x1")),
+        )
+    )
+
+    prompt_amounts = [
+        (Balance.from_tao(1.0), False),
+        (Balance.from_tao(2.0), False),
+        (Balance.from_tao(3.0), False),
+        (Balance.from_tao(4.0), False),
+    ]
+
+    with (
+        patch(
+            "bittensor_cli.src.commands.stake.add._prompt_stake_amount",
+            side_effect=prompt_amounts,
+        ),
+        patch(
+            "bittensor_cli.src.commands.stake.add.unlock_key",
+            return_value=MagicMock(success=True),
+        ),
+    ):
+        await stake_add(
+            wallet=mock_wallet,
+            subtensor=mock_subtensor,
+            netuids=[427, 1],
+            stake_all=False,
+            amount=0,
+            prompt=False,
+            decline=False,
+            quiet=True,
+            all_hotkeys=False,
+            include_hotkeys=[TEST_SS58, ALT_HOTKEY_SS58],
+            exclude_hotkeys=[],
+            safe_staking=False,
+            rate_tolerance=0.05,
+            allow_partial_stake=True,
+            json_output=True,
+            era=16,
+            mev_protection=False,
+            proxy=None,
+        )
+
+    batched_stake_calls = [
+        call
+        for call in mock_subtensor.substrate.compose_call.await_args_list
+        if call.kwargs.get("block_hash") == "0xabc123"
+    ]
+
+    assert len(batched_stake_calls) == 4
+    assert [
+        (
+            call.kwargs["call_params"]["hotkey"],
+            call.kwargs["call_params"]["netuid"],
+            call.kwargs["call_params"]["amount_staked"],
+        )
+        for call in batched_stake_calls
+    ] == [
+        (TEST_SS58, 427, Balance.from_tao(1.0).rao),
+        (TEST_SS58, 1, Balance.from_tao(2.0).rao),
+        (ALT_HOTKEY_SS58, 427, Balance.from_tao(3.0).rao),
+        (ALT_HOTKEY_SS58, 1, Balance.from_tao(4.0).rao),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_stake_add_stake_all_distributes_across_all_operations(
+    mock_wallet,
+    mock_subtensor,
+):
+    mock_subtensor.sim_swap = _sim_swap_side_effect()
+    mock_subtensor.all_subnets.return_value = [
+        MockSubnetInfo(netuid=427, price_tao=1.5),
+        MockSubnetInfo(netuid=1, price_tao=2.0),
+    ]
+    mock_subtensor.sign_and_send_batch_extrinsic = AsyncMock(
+        return_value=(
+            True,
+            "",
+            MagicMock(get_extrinsic_identifier=AsyncMock(return_value="0x1")),
+        )
+    )
+
+    with patch(
+        "bittensor_cli.src.commands.stake.add.unlock_key",
+        return_value=MagicMock(success=True),
+    ):
+        await stake_add(
+            wallet=mock_wallet,
+            subtensor=mock_subtensor,
+            netuids=[427, 1],
+            stake_all=True,
+            amount=0,
+            prompt=False,
+            decline=False,
+            quiet=True,
+            all_hotkeys=False,
+            include_hotkeys=[TEST_SS58, ALT_HOTKEY_SS58],
+            exclude_hotkeys=[],
+            safe_staking=False,
+            rate_tolerance=0.05,
+            allow_partial_stake=True,
+            json_output=True,
+            era=16,
+            mev_protection=False,
+            proxy=None,
+        )
+
+    batched_stake_calls = [
+        call
+        for call in mock_subtensor.substrate.compose_call.await_args_list
+        if call.kwargs.get("block_hash") == "0xabc123"
+    ]
+    expected_amount = (Balance.from_tao(100) / 4).rao
+
+    assert len(batched_stake_calls) == 4
+    assert all(
+        call.kwargs["call_params"]["amount_staked"] == expected_amount
+        for call in batched_stake_calls
+    )


### PR DESCRIPTION
Closes #896 

Fix `stake add` planning/execution to keep per-operation `(hotkey, netuid, amount, current_stake, price_limit)` alignment end-to-end, instead of rebuilding operations with `zip(...)`.

Also fix `stake_all` allocation to divide across total valid operations (not only `len(netuids)`), and add regression tests for:
- multi-hotkey + multi-netuid mapping correctness
- `stake_all` distribution across all operations
