### PR TITLE
fix: update max_burn to owner/sudo settable and align no-prompt routing

### DIFF
--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -609,7 +609,7 @@ HYPERPARAMS = {
         RootSudoOnly.TRUE,
     ),
     "min_burn": ("sudo_set_min_burn", RootSudoOnly.FALSE),
-    "max_burn": ("sudo_set_max_burn", RootSudoOnly.TRUE),
+    "max_burn": ("sudo_set_max_burn", RootSudoOnly.COMPLICATED),
     "bonds_moving_avg": ("sudo_set_bonds_moving_average", RootSudoOnly.FALSE),
     "max_regs_per_block": ("sudo_set_max_registrations_per_block", RootSudoOnly.TRUE),
     "serving_rate_limit": ("sudo_set_serving_rate_limit", RootSudoOnly.FALSE),
@@ -745,7 +745,7 @@ HYPERPARAMS_METADATA = {
     "max_burn": {
         "description": "Maximum TAO burn amount cap for subnet registration.",
         "side_effects": "Caps registration costs, ensuring registration remains accessible even as difficulty increases.",
-        "owner_settable": False,
+        "owner_settable": True,
         "docs_link": "docs.learnbittensor.org/subnets/subnet-hyperparameters#maxburn",
     },
     "bonds_moving_avg": {

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -614,7 +614,9 @@ async def set_hyperparameter_extrinsic(
         )
     elif sudo_ is RootSudoOnly.COMPLICATED:
         if not prompt:
-            to_sudo_or_not_to_sudo = True  # default to sudo true when no-prompt is set
+            # In no-prompt mode, owners should take the owner path; non-owners
+            # should default to sudo.
+            to_sudo_or_not_to_sudo = subnet_owner != coldkey_ss58
         else:
             to_sudo_or_not_to_sudo = confirm_action(
                 "This hyperparam can be executed as sudo or not. Do you want to execute as sudo [y] or not [n]?",

--- a/tests/e2e_tests/test_staking_sudo.py
+++ b/tests/e2e_tests/test_staking_sudo.py
@@ -543,6 +543,7 @@ def test_staking(local_chain, wallet_setup):
     assert "description" in max_burn_param, "Missing description for max_burn"
     assert "side_effects" in max_burn_param, "Missing side_effects for max_burn"
     assert "owner_settable" in max_burn_param, "Missing owner_settable for max_burn"
+    assert max_burn_param["owner_settable"] is True
     assert "docs_link" in max_burn_param, "Missing docs_link for max_burn"
     max_burn_tao_from_json = max_burn_param["value"]
     assert Balance.from_rao(max_burn_tao_from_json) == Balance.from_tao(100.0)
@@ -626,6 +627,7 @@ def test_staking(local_chain, wallet_setup):
     assert "owner_settable" in max_burn_updated, (
         "Missing owner_settable for max_burn after update"
     )
+    assert max_burn_updated["owner_settable"] is True
     assert "docs_link" in max_burn_updated, (
         "Missing docs_link for max_burn after update"
     )

--- a/tests/unit_tests/test_hyperparams.py
+++ b/tests/unit_tests/test_hyperparams.py
@@ -38,3 +38,12 @@ def test_new_hyperparams_have_metadata():
 def test_new_hyperparams_owner_settable_true():
     for key in NEW_HYPERPARAMS_826:
         assert HYPERPARAMS_METADATA[key]["owner_settable"] is True
+
+
+def test_max_burn_is_owner_or_root_settable():
+    _, root_only = HYPERPARAMS["max_burn"]
+    assert root_only is RootSudoOnly.COMPLICATED
+
+
+def test_max_burn_metadata_owner_settable_true():
+    assert HYPERPARAMS_METADATA["max_burn"]["owner_settable"] is True

--- a/tests/unit_tests/test_sudo_hyperparameter_permissions.py
+++ b/tests/unit_tests/test_sudo_hyperparameter_permissions.py
@@ -5,16 +5,13 @@ from tests.unit_tests.conftest import COLDKEY_SS58
 
 
 MODULE = "bittensor_cli.src.commands.sudo"
-
-
-def _receipt() -> MagicMock:
-    receipt = MagicMock()
-    receipt.get_extrinsic_identifier = AsyncMock(return_value="0xabc-1")
-    return receipt
+NON_OWNER_SS58 = "5FLSigC9H8M5Xo6z8xN7f6cXnHboRcgk4v6R7zDNz6w5jN3q"
 
 
 @pytest.mark.asyncio
-async def test_max_burn_no_prompt_owner_uses_owner_path(mock_wallet, mock_subtensor):
+async def test_max_burn_no_prompt_owner_uses_owner_path(
+    mock_wallet, mock_subtensor, successful_receipt
+):
     from bittensor_cli.src.commands.sudo import set_hyperparameter_extrinsic
 
     direct_call = MagicMock(name="direct_call")
@@ -25,7 +22,7 @@ async def test_max_burn_no_prompt_owner_uses_owner_path(mock_wallet, mock_subten
     )
     mock_subtensor.substrate.compose_call = AsyncMock(return_value=direct_call)
     mock_subtensor.sign_and_send_extrinsic = AsyncMock(
-        return_value=(True, "", _receipt())
+        return_value=(True, "", successful_receipt)
     )
 
     with (
@@ -47,7 +44,7 @@ async def test_max_burn_no_prompt_owner_uses_owner_path(mock_wallet, mock_subten
 
     assert success is True
     assert err_msg == ""
-    assert ext_id == "0xabc-1"
+    assert ext_id == "0x123-1"
     mock_subtensor.substrate.compose_call.assert_awaited_once_with(
         call_module="AdminUtils",
         call_function="sudo_set_max_burn",
@@ -63,14 +60,14 @@ async def test_max_burn_no_prompt_owner_uses_owner_path(mock_wallet, mock_subten
 
 
 @pytest.mark.asyncio
-async def test_max_burn_no_prompt_non_owner_uses_sudo_path(mock_wallet, mock_subtensor):
+async def test_max_burn_no_prompt_non_owner_uses_sudo_path(
+    mock_wallet, mock_subtensor, successful_receipt
+):
     from bittensor_cli.src.commands.sudo import set_hyperparameter_extrinsic
 
     direct_call = MagicMock(name="direct_call")
     sudo_call = MagicMock(name="sudo_call")
-    mock_subtensor.query = AsyncMock(
-        return_value="5FLSigC9H8M5Xo6z8xN7f6cXnHboRcgk4v6R7zDNz6w5jN3q"
-    )
+    mock_subtensor.query = AsyncMock(return_value=NON_OWNER_SS58)
     mock_subtensor.substrate.metadata = MagicMock()
     mock_subtensor.substrate.get_metadata_call_function = AsyncMock(
         return_value={"fields": [{"name": "netuid"}, {"name": "max_burn"}]}
@@ -79,7 +76,7 @@ async def test_max_burn_no_prompt_non_owner_uses_sudo_path(mock_wallet, mock_sub
         side_effect=[direct_call, sudo_call]
     )
     mock_subtensor.sign_and_send_extrinsic = AsyncMock(
-        return_value=(True, "", _receipt())
+        return_value=(True, "", successful_receipt)
     )
 
     with (
@@ -101,7 +98,7 @@ async def test_max_burn_no_prompt_non_owner_uses_sudo_path(mock_wallet, mock_sub
 
     assert success is True
     assert err_msg == ""
-    assert ext_id == "0xabc-1"
+    assert ext_id == "0x123-1"
     assert mock_subtensor.substrate.compose_call.await_count == 2
     assert mock_subtensor.substrate.compose_call.await_args_list[0].kwargs == {
         "call_module": "AdminUtils",
@@ -120,3 +117,102 @@ async def test_max_burn_no_prompt_non_owner_uses_sudo_path(mock_wallet, mock_sub
         False,
         proxy=None,
     )
+
+
+@pytest.mark.asyncio
+async def test_max_burn_interactive_owner_chooses_non_sudo_path(
+    mock_wallet, mock_subtensor, successful_receipt
+):
+    from bittensor_cli.src.commands.sudo import set_hyperparameter_extrinsic
+
+    direct_call = MagicMock(name="direct_call")
+    mock_subtensor.query = AsyncMock(return_value=COLDKEY_SS58)
+    mock_subtensor.substrate.metadata = MagicMock()
+    mock_subtensor.substrate.get_metadata_call_function = AsyncMock(
+        return_value={"fields": [{"name": "netuid"}, {"name": "max_burn"}]}
+    )
+    mock_subtensor.substrate.compose_call = AsyncMock(return_value=direct_call)
+    mock_subtensor.sign_and_send_extrinsic = AsyncMock(
+        return_value=(True, "", successful_receipt)
+    )
+
+    with (
+        patch(f"{MODULE}.unlock_key", return_value=MagicMock(success=True)),
+        patch(f"{MODULE}.requires_bool", return_value=False),
+        patch(f"{MODULE}.confirm_action", return_value=False),
+        patch(f"{MODULE}.print_extrinsic_id", new_callable=AsyncMock),
+    ):
+        success, err_msg, ext_id = await set_hyperparameter_extrinsic(
+            subtensor=mock_subtensor,
+            wallet=mock_wallet,
+            netuid=1,
+            proxy=None,
+            parameter="max_burn",
+            value="10000000000",
+            wait_for_inclusion=False,
+            wait_for_finalization=False,
+            prompt=True,
+            decline=False,
+            quiet=True,
+        )
+
+    assert success is True
+    assert err_msg == ""
+    assert ext_id == "0x123-1"
+    mock_subtensor.substrate.compose_call.assert_awaited_once_with(
+        call_module="AdminUtils",
+        call_function="sudo_set_max_burn",
+        call_params={"netuid": 1, "max_burn": "10000000000"},
+    )
+    mock_subtensor.sign_and_send_extrinsic.assert_awaited_once_with(
+        direct_call,
+        mock_wallet,
+        False,
+        False,
+        proxy=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_max_burn_interactive_non_owner_chooses_non_sudo_errors(
+    mock_wallet, mock_subtensor
+):
+    from bittensor_cli.src.commands.sudo import set_hyperparameter_extrinsic
+
+    direct_call = MagicMock(name="direct_call")
+    mock_subtensor.query = AsyncMock(return_value=NON_OWNER_SS58)
+    mock_subtensor.substrate.metadata = MagicMock()
+    mock_subtensor.substrate.get_metadata_call_function = AsyncMock(
+        return_value={"fields": [{"name": "netuid"}, {"name": "max_burn"}]}
+    )
+    mock_subtensor.substrate.compose_call = AsyncMock(return_value=direct_call)
+    mock_subtensor.sign_and_send_extrinsic = AsyncMock()
+
+    with (
+        patch(f"{MODULE}.unlock_key", return_value=MagicMock(success=True)),
+        patch(f"{MODULE}.requires_bool", return_value=False),
+        patch(f"{MODULE}.confirm_action", return_value=False),
+    ):
+        success, err_msg, ext_id = await set_hyperparameter_extrinsic(
+            subtensor=mock_subtensor,
+            wallet=mock_wallet,
+            netuid=1,
+            proxy=None,
+            parameter="max_burn",
+            value="10000000000",
+            wait_for_inclusion=False,
+            wait_for_finalization=False,
+            prompt=True,
+            decline=False,
+            quiet=True,
+        )
+
+    assert success is False
+    assert err_msg == "This wallet doesn't own the specified subnet."
+    assert ext_id is None
+    mock_subtensor.substrate.compose_call.assert_awaited_once_with(
+        call_module="AdminUtils",
+        call_function="sudo_set_max_burn",
+        call_params={"netuid": 1, "max_burn": "10000000000"},
+    )
+    mock_subtensor.sign_and_send_extrinsic.assert_not_awaited()

--- a/tests/unit_tests/test_sudo_hyperparameter_permissions.py
+++ b/tests/unit_tests/test_sudo_hyperparameter_permissions.py
@@ -1,0 +1,122 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from tests.unit_tests.conftest import COLDKEY_SS58
+
+
+MODULE = "bittensor_cli.src.commands.sudo"
+
+
+def _receipt() -> MagicMock:
+    receipt = MagicMock()
+    receipt.get_extrinsic_identifier = AsyncMock(return_value="0xabc-1")
+    return receipt
+
+
+@pytest.mark.asyncio
+async def test_max_burn_no_prompt_owner_uses_owner_path(mock_wallet, mock_subtensor):
+    from bittensor_cli.src.commands.sudo import set_hyperparameter_extrinsic
+
+    direct_call = MagicMock(name="direct_call")
+    mock_subtensor.query = AsyncMock(return_value=COLDKEY_SS58)
+    mock_subtensor.substrate.metadata = MagicMock()
+    mock_subtensor.substrate.get_metadata_call_function = AsyncMock(
+        return_value={"fields": [{"name": "netuid"}, {"name": "max_burn"}]}
+    )
+    mock_subtensor.substrate.compose_call = AsyncMock(return_value=direct_call)
+    mock_subtensor.sign_and_send_extrinsic = AsyncMock(
+        return_value=(True, "", _receipt())
+    )
+
+    with (
+        patch(f"{MODULE}.unlock_key", return_value=MagicMock(success=True)),
+        patch(f"{MODULE}.requires_bool", return_value=False),
+        patch(f"{MODULE}.print_extrinsic_id", new_callable=AsyncMock),
+    ):
+        success, err_msg, ext_id = await set_hyperparameter_extrinsic(
+            subtensor=mock_subtensor,
+            wallet=mock_wallet,
+            netuid=1,
+            proxy=None,
+            parameter="max_burn",
+            value="10000000000",
+            wait_for_inclusion=False,
+            wait_for_finalization=False,
+            prompt=False,
+        )
+
+    assert success is True
+    assert err_msg == ""
+    assert ext_id == "0xabc-1"
+    mock_subtensor.substrate.compose_call.assert_awaited_once_with(
+        call_module="AdminUtils",
+        call_function="sudo_set_max_burn",
+        call_params={"netuid": 1, "max_burn": "10000000000"},
+    )
+    mock_subtensor.sign_and_send_extrinsic.assert_awaited_once_with(
+        direct_call,
+        mock_wallet,
+        False,
+        False,
+        proxy=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_max_burn_no_prompt_non_owner_uses_sudo_path(mock_wallet, mock_subtensor):
+    from bittensor_cli.src.commands.sudo import set_hyperparameter_extrinsic
+
+    direct_call = MagicMock(name="direct_call")
+    sudo_call = MagicMock(name="sudo_call")
+    mock_subtensor.query = AsyncMock(
+        return_value="5FLSigC9H8M5Xo6z8xN7f6cXnHboRcgk4v6R7zDNz6w5jN3q"
+    )
+    mock_subtensor.substrate.metadata = MagicMock()
+    mock_subtensor.substrate.get_metadata_call_function = AsyncMock(
+        return_value={"fields": [{"name": "netuid"}, {"name": "max_burn"}]}
+    )
+    mock_subtensor.substrate.compose_call = AsyncMock(
+        side_effect=[direct_call, sudo_call]
+    )
+    mock_subtensor.sign_and_send_extrinsic = AsyncMock(
+        return_value=(True, "", _receipt())
+    )
+
+    with (
+        patch(f"{MODULE}.unlock_key", return_value=MagicMock(success=True)),
+        patch(f"{MODULE}.requires_bool", return_value=False),
+        patch(f"{MODULE}.print_extrinsic_id", new_callable=AsyncMock),
+    ):
+        success, err_msg, ext_id = await set_hyperparameter_extrinsic(
+            subtensor=mock_subtensor,
+            wallet=mock_wallet,
+            netuid=1,
+            proxy=None,
+            parameter="max_burn",
+            value="10000000000",
+            wait_for_inclusion=False,
+            wait_for_finalization=False,
+            prompt=False,
+        )
+
+    assert success is True
+    assert err_msg == ""
+    assert ext_id == "0xabc-1"
+    assert mock_subtensor.substrate.compose_call.await_count == 2
+    assert mock_subtensor.substrate.compose_call.await_args_list[0].kwargs == {
+        "call_module": "AdminUtils",
+        "call_function": "sudo_set_max_burn",
+        "call_params": {"netuid": 1, "max_burn": "10000000000"},
+    }
+    assert mock_subtensor.substrate.compose_call.await_args_list[1].kwargs == {
+        "call_module": "Sudo",
+        "call_function": "sudo",
+        "call_params": {"call": direct_call},
+    }
+    mock_subtensor.sign_and_send_extrinsic.assert_awaited_once_with(
+        sudo_call,
+        mock_wallet,
+        False,
+        False,
+        proxy=None,
+    )


### PR DESCRIPTION
Closes #901

Update `max_burn` to owner/sudo settable and align `owner_settable` metadata.
Also fixes `--no-prompt` routing for `RootSudoOnly.COMPLICATED`: owners use owner path, non-owners default to sudo.
