### PR TITLE
Updates conftest imports

### DIFF
--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -4,7 +4,7 @@ Shared fixtures for btcli unit tests.
 Provides common mock objects, SS58 address constants, and receipt helpers that
 are duplicated across multiple test files. Import constants directly:
 
-    from conftest import COLDKEY_SS58, HOTKEY_SS58, ...
+    from .conftest import COLDKEY_SS58, HOTKEY_SS58, ...
 
 Fixtures (mock_wallet, mock_wallet_spec, mock_subtensor, successful_receipt,
 failed_receipt) are discovered automatically by pytest.

--- a/tests/unit_tests/test_crowd_proxy_creator_checks.py
+++ b/tests/unit_tests/test_crowd_proxy_creator_checks.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from bittensor_cli.src.bittensor.balances import Balance
-from tests.unit_tests.conftest import COLDKEY_SS58, PROXY_SS58
+from .conftest import COLDKEY_SS58, PROXY_SS58
 
 
 def _make_crowdloan(

--- a/tests/unit_tests/test_proxy_address_resolution.py
+++ b/tests/unit_tests/test_proxy_address_resolution.py
@@ -8,8 +8,7 @@ import pytest
 from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from bittensor_cli.src.bittensor.balances import Balance
-from tests.unit_tests.conftest import (
+from .conftest import (
     PROXY_SS58,
     HOTKEY_SS58,
     DEST_SS58 as DEST_HOTKEY_SS58,

--- a/tests/unit_tests/test_root_extrinsics.py
+++ b/tests/unit_tests/test_root_extrinsics.py
@@ -17,7 +17,7 @@ from bittensor_cli.src.bittensor.extrinsics.root import (
     get_current_weights_for_uid,
     get_limits,
 )
-from tests.unit_tests.conftest import COLDKEY_SS58 as _SS58
+from .conftest import COLDKEY_SS58 as _SS58
 
 U16_MAX = 65535
 

--- a/tests/unit_tests/test_stake_add.py
+++ b/tests/unit_tests/test_stake_add.py
@@ -6,7 +6,7 @@ import pytest
 from bittensor_cli.src.bittensor.balances import Balance
 from bittensor_cli.src.commands.stake.add import stake_add
 
-from tests.unit_tests.conftest import (
+from .conftest import (
     ALT_HOTKEY_SS58,
     COLDKEY_SS58 as TEST_SS58,
 )

--- a/tests/unit_tests/test_stake_move.py
+++ b/tests/unit_tests/test_stake_move.py
@@ -16,7 +16,7 @@ from bittensor_cli.src.commands.stake.move import (
     stake_move_transfer_selection,
     move_stake,
 )
-from tests.unit_tests.conftest import HOTKEY_SS58, ALT_HOTKEY_SS58
+from .conftest import HOTKEY_SS58, ALT_HOTKEY_SS58
 
 MODULE = "bittensor_cli.src.commands.stake.move"
 

--- a/tests/unit_tests/test_sudo_hyperparameter_permissions.py
+++ b/tests/unit_tests/test_sudo_hyperparameter_permissions.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from tests.unit_tests.conftest import COLDKEY_SS58
+from .conftest import COLDKEY_SS58
 
 
 MODULE = "bittensor_cli.src.commands.sudo"

--- a/tests/unit_tests/test_transfer_extrinsic.py
+++ b/tests/unit_tests/test_transfer_extrinsic.py
@@ -5,13 +5,11 @@ Tests the branching logic in transfer_extrinsic using the shared mock_wallet
 and mock_subtensor fixtures from conftest.py.
 """
 
-import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from bittensor_cli.src.bittensor.balances import Balance
 from bittensor_cli.src.bittensor.extrinsics.transfer import transfer_extrinsic
-from tests.unit_tests.conftest import DEST_SS58 as _DEST_SS58
-from tests.unit_tests.conftest import PROXY_SS58 as _PROXY_SS58
+from .conftest import DEST_SS58 as _DEST_SS58, PROXY_SS58 as _PROXY_SS58
 
 # An invalid destination
 _INVALID_DEST = "not_a_valid_address"

--- a/tests/unit_tests/test_unstake_helpers.py
+++ b/tests/unit_tests/test_unstake_helpers.py
@@ -9,7 +9,6 @@ running the full unstake flow:
   - _print_table_and_slippage
 """
 
-import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -22,7 +21,7 @@ from bittensor_cli.src.commands.stake.remove import (
     get_hotkey_identity,
 )
 from bittensor_cli.src.bittensor.balances import Balance
-from tests.unit_tests.conftest import (
+from .conftest import (
     PROXY_SS58 as _HOTKEY_SS58,
     COLDKEY_SS58 as _COLDKEY_SS58,
 )

--- a/tests/unit_tests/test_utils_pure.py
+++ b/tests/unit_tests/test_utils_pure.py
@@ -24,7 +24,7 @@ from bittensor_cli.src.bittensor.utils import (
     format_error_message,
     validate_netuid,
 )
-from tests.unit_tests.conftest import COLDKEY_SS58 as _VALID_SS58
+from .conftest import COLDKEY_SS58 as _VALID_SS58
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Updates conftest imports to relative so as to avoid name collision with other packages like ASI, specifically fixes https://github.com/latent-to/async-substrate-interface/pull/288