### PR TITLE
fix(subnets): disable Progress auto_refresh inside Live display for macOS Terminal compatibility

### DIFF
--- a/bittensor_cli/src/commands/subnets/subnets.py
+++ b/bittensor_cli/src/commands/subnets/subnets.py
@@ -916,7 +916,7 @@ async def subnets_list(
             BarColumn(bar_width=20, style="green", complete_style="green"),
             TextColumn("[progress.percentage]{task.percentage:>3.0f}%"),
             console=console,
-            auto_refresh=True,
+            auto_refresh=False,
         )
         progress_task = progress.add_task("Updating:", total=refresh_interval)
 


### PR DESCRIPTION
## summary

fixes #315
the `--live` option for `subnets list` renders incorrectly on macOS Terminal.app because the `Progress` widget inside the `Live` display has `auto_refresh=True`, causing it to write ANSI escape sequences directly to the terminal on its own refresh cycle
the fix disables `auto_refresh` on the `Progress` widget and drives refresh manually inside the `Live` loop

## test plan

manual testing on macOS Terminal.app confirms the display renders correctly without ANSI artifacts