### PR TITLE
fix: return empty string instead of implicit None in get_decoded

### DIFF
--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -834,13 +834,20 @@ def decode_hex_identity_dict(info_dictionary) -> dict[str, Any]:
     """
 
     def get_decoded(data: Optional[str]) -> str:
-        """Decodes a hex-encoded string."""
+        """Decodes a hex-encoded string.
+
+        Returns an empty string when *data* is ``None`` or when the payload
+        cannot be decoded (malformed hex or invalid UTF-8).  Previously the
+        except branch had no ``return`` statement, so the function returned
+        ``None`` implicitly — propagating into downstream string operations
+        and causing ``TypeError``.
+        """
         if data is None:
             return ""
         try:
             return hex_to_bytes(data).decode()
         except (UnicodeDecodeError, ValueError):
-            print(f"Could not decode: {key}: {item}")
+            return ""
 
     for key, value in info_dictionary.items():
         if isinstance(value, dict):


### PR DESCRIPTION
## Problem

`get_decoded()` inside `decode_hex_identity_dict` catches `UnicodeDecodeError` / `ValueError` but has no `return` statement in the except branch. This means it returns `None` implicitly, which propagates into the identity dictionary. Downstream code that expects string values (formatting, concatenation, display) then crashes with `TypeError: expected str, got NoneType`.

The except branch also called `print(f"Could not decode: {key}: {item}")` referencing closure variables `key` and `item` from the outer loop — fragile and inconsistent since `get_decoded` is also called from the `additional` loop where those variables may not match.

## Solution

Return `""` (empty string) on decode failure, consistent with the `data is None` path. Remove the debug `print()` that referenced outer-scope variables.

## Type of Change
- [x] Bug fix

## Testing
- [x] `ruff check` passes
- [x] `ruff format` passes
- [x] Self-reviewed