### PR TITLE
fix(sudo): guard stake_burn rate inversions on zero prices

### DIFF
--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -172,7 +172,7 @@ async def stake_burn(
 
         received_amount = sim_swap.alpha_amount
         current_price_float = subnet_info.price.tao
-        rate = 1.0 / current_price_float
+        rate = 1.0 / current_price_float if current_price_float > 0 else 0.0
 
         table = _define_stake_burn_table(
             wallet=wallet,
@@ -191,7 +191,9 @@ async def stake_burn(
         ]
         if safe_staking:
             price_with_tolerance = current_price_float * (1 + rate_tolerance)
-            rate_with_tolerance = 1.0 / price_with_tolerance
+            rate_with_tolerance = (
+                1.0 / price_with_tolerance if price_with_tolerance > 0 else 0.0
+            )
             rate_with_tolerance_str = (
                 f"{rate_with_tolerance:.4f} "
                 f"{Balance.get_unit(netuid)}/{Balance.get_unit(0)} "

--- a/tests/unit_tests/test_sudo_stake_burn.py
+++ b/tests/unit_tests/test_sudo_stake_burn.py
@@ -1,0 +1,67 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bittensor_cli.src.bittensor.balances import Balance
+from bittensor_cli.src.commands.sudo import stake_burn
+
+from tests.unit_tests.conftest import COLDKEY_SS58 as TEST_SS58, HOTKEY_SS58
+
+
+class MockSubnetInfo:
+    def __init__(self, netuid: int, price_tao: float):
+        self.netuid = netuid
+        self.price = Balance.from_tao(price_tao)
+        self.is_dynamic = netuid != 0
+
+
+def _sim_swap_side_effect():
+    async def sim_swap_mock(origin_netuid, destination_netuid, amount, **kwargs):
+        del origin_netuid, amount, kwargs
+        return SimpleNamespace(
+            alpha_amount=Balance.from_tao(1).set_unit(destination_netuid),
+            tao_fee=Balance.from_tao(0.1),
+        )
+
+    return AsyncMock(side_effect=sim_swap_mock)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("safe_staking", [False, True])
+async def test_stake_burn_zero_price_does_not_raise(
+    mock_wallet,
+    mock_subtensor,
+    safe_staking,
+):
+    netuid = 427
+    mock_subtensor.query = AsyncMock(return_value=TEST_SS58)
+    mock_subtensor.substrate.get_block_hash = AsyncMock(return_value="0xdeadbeef")
+    mock_subtensor.subnet = AsyncMock(
+        return_value=MockSubnetInfo(netuid=netuid, price_tao=0)
+    )
+    mock_subtensor.sim_swap = _sim_swap_side_effect()
+
+    with patch("bittensor_cli.src.commands.sudo.confirm_action", return_value=False):
+        result = await stake_burn(
+            wallet=mock_wallet,
+            subtensor=mock_subtensor,
+            netuid=netuid,
+            amount=10.0,
+            hotkey_ss58=HOTKEY_SS58,
+            safe_staking=safe_staking,
+            proxy=None,
+            rate_tolerance=0.05,
+            mev_protection=False,
+            json_output=False,
+            prompt=True,
+            decline=False,
+            quiet=True,
+            period=16,
+        )
+
+    assert result is False
+    assert mock_subtensor.substrate.compose_call.await_count == 1
+    composed_call = mock_subtensor.substrate.compose_call.await_args.kwargs
+    assert composed_call["call_function"] == "add_stake_burn"
+    assert mock_subtensor.sim_swap.await_count == 1


### PR DESCRIPTION
## Summary

- `stake_burn` in `bittensor_cli/src/commands/sudo.py` computes `rate = 1.0 / current_price_float` (line 177) and `rate_with_tolerance = 1.0 / price_with_tolerance` (line 196) without guarding against a zero price, so burning stake on a zero-priced subnet raises `ZeroDivisionError` before the extrinsic is submitted.
- Inline the same `> 0` guard at both sites, matching the `_safe_inverse_rate()` intent that PR #886 introduced in `stake/add.py` for this exact class of crash — the sudo burn path was the sibling that was missed.
- Add `tests/unit_tests/test_sudo_stake_burn.py` covering both `safe_staking=False` and `safe_staking=True` against a zero-priced subnet. Reverting the fix reproduces `ZeroDivisionError: float division by zero` at `sudo.py:177` in the test.

## Related Issues

N/A — code review. Same class of bug as #886 fixed in `stake/add.py`; the sibling site in `sudo.stake_burn` was not updated.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [x] Tests added (`tests/unit_tests/test_sudo_stake_burn.py`, 2 cases)
- [x] Existing `tests/unit_tests/test_stake_add.py` unchanged and still passing locally
- [x] Verified the fix reproduces the crash when reverted

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
