### PR TITLE
Do not unstake from hotkeys that do not exist on chain

### DIFF
--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -1022,6 +1022,36 @@ class SubtensorInterface:
 
         return b_map
 
+    async def do_hotkeys_exist(
+        self, hotkeys_ss58: Iterable[str], block_hash: Optional[str] = None
+    ) -> dict[str, bool]:
+        """
+        Checks whether a hotkey exists is known by the chain and there are accounts.
+
+        Args:
+            hotkeys_ss58: list of hotkey ss58s
+            block_hash: hash of the block to query
+
+        Returns:
+            {hotkey ss58: exists (True/False)}
+        """
+        if block_hash is None:
+            block_hash = await self.substrate.get_chain_head()
+        keys = [
+            await self.substrate.create_storage_key(
+                "SubtensorModule", "Owner", [ss58], block_hash=block_hash
+            )
+            for ss58 in hotkeys_ss58
+        ]
+        query = await self.substrate.query_multi(
+            storage_keys=keys,
+            block_hash=block_hash,
+        )
+        output: dict[str, bool] = {}
+        for key, value in query:
+            output[key.params[0]] = value != GENESIS_ADDRESS
+        return output
+
     async def does_hotkey_exist(
         self,
         hotkey_ss58: str,

--- a/bittensor_cli/src/commands/stake/add.py
+++ b/bittensor_cli/src/commands/stake/add.py
@@ -315,14 +315,58 @@ async def stake_add(
 
     # Get subnet data and stake information for coldkey
     chain_head = await subtensor.substrate.get_chain_head()
-    _all_subnets, _stake_info, current_wallet_balance = await asyncio.gather(
+    (
+        _all_subnets,
+        _stake_info,
+        current_wallet_balance,
+        hotkey_existence,
+    ) = await asyncio.gather(
         subtensor.all_subnets(block_hash=chain_head),
         subtensor.get_stake_for_coldkey(
             coldkey_ss58=coldkey_ss58,
             block_hash=chain_head,
         ),
         subtensor.get_balance(coldkey_ss58, block_hash=chain_head),
+        subtensor.do_hotkeys_exist(
+            [x[1] for x in hotkeys_to_stake_to],
+            block_hash=chain_head,
+        ),
     )
+    hotkeys_that_exists = [
+        x for x in hotkeys_to_stake_to if hotkey_existence[x[1]] is True
+    ]
+    if not hotkeys_that_exists:
+        err_msg = "No keys existing on chain that can be staked to."
+        if json_output:
+            json_console.print_json(
+                data={
+                    "staking_success": False,
+                    "error_messages": [err_msg],
+                    "extrinsic_ids": None,
+                }
+            )
+        else:
+            print_error(err_msg)
+        return None
+
+    if hotkeys_that_exists != hotkeys_to_stake_to:
+        difference = set(x[1] for x in hotkeys_to_stake_to).symmetric_difference(
+            set(x[1] for x in hotkeys_that_exists)
+        )
+        sames = set(x[1] for x in hotkeys_to_stake_to).intersection(
+            set(x[1] for x in hotkeys_that_exists)
+        )
+        msg = (
+            "Some hotkeys attempting to stake to are not present: "
+            + ", ".join(difference)
+            + ". Using hotkeys:\n"
+            + "\n".join(sames)
+        )
+        console.print(msg)
+        if prompt:
+            if not confirm_action("Do you want to continue?"):
+                return None
+    hotkeys_to_stake_to = hotkeys_that_exists
     all_subnets = {di.netuid: di for di in _all_subnets}
 
     # Map current stake balances for hotkeys

--- a/bittensor_cli/src/commands/stake/remove.py
+++ b/bittensor_cli/src/commands/stake/remove.py
@@ -127,9 +127,35 @@ async def unstake(
     hotkeys_existence = await subtensor.do_hotkeys_exist(
         [x[1] for x in hotkeys_to_unstake_from], block_hash=chain_head
     )
-    hotkeys_to_unstake_from = [
+    hotkeys_to_unstake_from_that_exist = [
         x for x in hotkeys_to_unstake_from if hotkeys_existence[x[1]] is True
     ]
+    if not hotkeys_to_unstake_from_that_exist:
+        err_msg = "No keys existing on chain from which to unstake"
+        if json_output:
+            json_console.print_json(data={"success": False, "error": err_msg})
+        else:
+            print_error(err_msg)
+        return False
+
+    if hotkeys_to_unstake_from_that_exist != hotkeys_to_unstake_from:
+        difference = set(x[1] for x in hotkeys_to_unstake_from).symmetric_difference(
+            set(x[1] for x in hotkeys_to_unstake_from_that_exist)
+        )
+        sames = set(x[1] for x in hotkeys_to_unstake_from).intersection(
+            set(x[1] for x in hotkeys_to_unstake_from_that_exist)
+        )
+        msg = (
+            "Some hotkeys attempting to unstake are not present: "
+            + ", ".join(difference)
+            + ". Using hotkeys:\n"
+            + "\n".join(sames)
+        )
+        console.print(msg)
+        if prompt:
+            if not confirm_action("Do you want to continue?"):
+                return False
+    hotkeys_to_unstake_from = hotkeys_to_unstake_from_that_exist
 
     with console.status(
         f"Retrieving stake data from {subtensor.network}...",

--- a/bittensor_cli/src/commands/stake/remove.py
+++ b/bittensor_cli/src/commands/stake/remove.py
@@ -544,6 +544,7 @@ async def unstake_all(
     include_hotkeys = include_hotkeys or []
     exclude_hotkeys = exclude_hotkeys or []
     coldkey_ss58 = proxy or wallet.coldkeypub.ss58_address
+    block_hash = await subtensor.substrate.get_chain_head()
     with console.status(
         f"Retrieving stake information & identities from {subtensor.network}...",
         spinner="earth",
@@ -554,10 +555,10 @@ async def unstake_all(
             all_sn_dynamic_info_,
             current_wallet_balance,
         ) = await asyncio.gather(
-            subtensor.get_stake_for_coldkey(coldkey_ss58),
-            subtensor.fetch_coldkey_hotkey_identities(),
-            subtensor.all_subnets(),
-            subtensor.get_balance(coldkey_ss58),
+            subtensor.get_stake_for_coldkey(coldkey_ss58, block_hash=block_hash),
+            subtensor.fetch_coldkey_hotkey_identities(block_hash=block_hash),
+            subtensor.all_subnets(block_hash=block_hash),
+            subtensor.get_balance(coldkey_ss58, block_hash=block_hash),
         )
 
         if all_hotkeys:
@@ -575,115 +576,147 @@ async def unstake_all(
         else:
             hotkeys = [(None, hotkey_ss58_address, None)]
 
-        hotkey_names = {ss58: name for name, ss58, _ in hotkeys if name is not None}
-        hotkey_ss58s = [item[1] for item in hotkeys]
-        stake_info = [
-            stake for stake in stake_info if stake.hotkey_ss58 in hotkey_ss58s
-        ]
-
-        if unstake_all_alpha:
-            stake_info = [stake for stake in stake_info if stake.netuid != 0]
-
-        if not stake_info:
-            console.print("[red]No stakes found to unstake[/red]")
-            return
-
-        all_sn_dynamic_info = {info.netuid: info for info in all_sn_dynamic_info_}
-
-        # Create table for unstaking all
-        table_title = (
-            "Unstaking Summary - All Stakes"
-            if not unstake_all_alpha
-            else "Unstaking Summary - All Alpha Stakes"
+        hotkeys_existence = await subtensor.do_hotkeys_exist(
+            [x[1] for x in hotkeys], block_hash=block_hash
         )
-        table = create_table(
-            title=(
-                f"\n[{COLOR_PALETTE.G.HEADER}]{table_title}[/{COLOR_PALETTE.G.HEADER}]\n"
-                f"Wallet: [{COLOR_PALETTE.G.COLDKEY}]{wallet.name}[/{COLOR_PALETTE.G.COLDKEY}], "
-                f"Coldkey ss58: [{COLOR_PALETTE.G.CK}]{coldkey_ss58}[/{COLOR_PALETTE.G.CK}]\n"
-                f"Network: [{COLOR_PALETTE.G.HEADER}]{subtensor.network}[/{COLOR_PALETTE.G.HEADER}]\n"
-            ),
-        )
-        table.add_column("Netuid", justify="center", style="grey89")
-        table.add_column(
-            "Hotkey", justify="center", style=COLOR_PALETTE["GENERAL"]["HOTKEY"]
-        )
-        table.add_column(
-            f"Current Stake ({Balance.get_unit(1)})",
-            justify="center",
-            style=COLOR_PALETTE["STAKE"]["STAKE_ALPHA"],
-        )
-        table.add_column(
-            f"Rate ({Balance.unit}/{Balance.get_unit(1)})",
-            justify="center",
-            style=COLOR_PALETTE["POOLS"]["RATE"],
-        )
-        table.add_column(
-            f"Fee ({Balance.get_unit(1)})",
-            justify="center",
-            style=COLOR_PALETTE["STAKE"]["STAKE_AMOUNT"],
-        )
-        table.add_column(
-            "Extrinsic Fee (τ)",
-            justify="center",
-            style=COLOR_PALETTE.STAKE.TAO,
-        )
-        table.add_column(
-            f"Received ({Balance.unit})",
-            justify="center",
-            style=COLOR_PALETTE["POOLS"]["TAO_EQUIV"],
-        )
-        # table.add_column(
-        #     "Slippage",
-        #     justify="center",
-        #     style=COLOR_PALETTE["STAKE"]["SLIPPAGE_PERCENT"],
-        # )
 
-        # Calculate total received
-        total_received_value = Balance(0)
-        for stake in stake_info:
-            if stake.stake.rao == 0:
-                continue
+    hotkeys_to_unstake_from_that_exist = [
+        x for x in hotkeys if hotkeys_existence[x[1]] is True
+    ]
+    if not hotkeys_to_unstake_from_that_exist:
+        err_msg = "No keys existing on chain from which to unstake"
+        if json_output:
+            json_console.print_json(data={"success": False, "error": err_msg})
+        else:
+            print_error(err_msg)
+        return None
 
-            hotkey_display = hotkey_names.get(stake.hotkey_ss58, stake.hotkey_ss58)
-            subnet_info = all_sn_dynamic_info.get(stake.netuid)
-            stake_amount = stake.stake
+    if hotkeys_to_unstake_from_that_exist != hotkeys:
+        difference = set(x[1] for x in hotkeys).symmetric_difference(
+            set(x[1] for x in hotkeys_to_unstake_from_that_exist)
+        )
+        sames = set(x[1] for x in hotkeys).intersection(
+            set(x[1] for x in hotkeys_to_unstake_from_that_exist)
+        )
+        msg = (
+            "Some hotkeys attempting to unstake are not present: "
+            + ", ".join(difference)
+            + ". Using hotkeys:\n"
+            + "\n".join(sames)
+        )
+        console.print(msg)
+        if prompt:
+            if not confirm_action("Do you want to continue?"):
+                return None
+    hotkeys = hotkeys_to_unstake_from_that_exist
 
-            try:
-                _ = subnet_info.price.tao
-                extrinsic_type = (
-                    "unstake_all" if not unstake_all_alpha else "unstake_all_alpha"
-                )
-                extrinsic_fee = await _get_extrinsic_fee(
-                    extrinsic_type,
-                    wallet,
-                    subtensor,
-                    hotkey_ss58=stake.hotkey_ss58,
-                    proxy=proxy,
-                )
-                sim_swap = await subtensor.sim_swap(stake.netuid, 0, stake_amount.rao)
-                received_amount = sim_swap.tao_amount
-                if not proxy:
-                    received_amount -= extrinsic_fee
+    hotkey_names = {ss58: name for name, ss58, _ in hotkeys if name is not None}
+    hotkey_ss58s = [item[1] for item in hotkeys]
+    stake_info = [stake for stake in stake_info if stake.hotkey_ss58 in hotkey_ss58s]
 
-                if received_amount < Balance.from_tao(0):
-                    print_error("Not enough Alpha to pay the transaction fee.")
-                    continue
-            except (AttributeError, ValueError):
-                continue
+    if unstake_all_alpha:
+        stake_info = [stake for stake in stake_info if stake.netuid != 0]
 
-            total_received_value += received_amount
+    if not stake_info:
+        console.print("[red]No stakes found to unstake[/red]")
+        return
 
-            table.add_row(
-                str(stake.netuid),
-                hotkey_display,
-                str(stake_amount),
-                f"{float(subnet_info.price):.6f}"
-                + f"({Balance.get_unit(0)}/{Balance.get_unit(stake.netuid)})",
-                str(sim_swap.alpha_fee),
-                str(extrinsic_fee),
-                str(received_amount),
+    all_sn_dynamic_info = {info.netuid: info for info in all_sn_dynamic_info_}
+
+    # Create table for unstaking all
+    table_title = (
+        "Unstaking Summary - All Stakes"
+        if not unstake_all_alpha
+        else "Unstaking Summary - All Alpha Stakes"
+    )
+    table = create_table(
+        title=(
+            f"\n[{COLOR_PALETTE.G.HEADER}]{table_title}[/{COLOR_PALETTE.G.HEADER}]\n"
+            f"Wallet: [{COLOR_PALETTE.G.COLDKEY}]{wallet.name}[/{COLOR_PALETTE.G.COLDKEY}], "
+            f"Coldkey ss58: [{COLOR_PALETTE.G.CK}]{coldkey_ss58}[/{COLOR_PALETTE.G.CK}]\n"
+            f"Network: [{COLOR_PALETTE.G.HEADER}]{subtensor.network}[/{COLOR_PALETTE.G.HEADER}]\n"
+        ),
+    )
+    table.add_column("Netuid", justify="center", style="grey89")
+    table.add_column(
+        "Hotkey", justify="center", style=COLOR_PALETTE["GENERAL"]["HOTKEY"]
+    )
+    table.add_column(
+        f"Current Stake ({Balance.get_unit(1)})",
+        justify="center",
+        style=COLOR_PALETTE["STAKE"]["STAKE_ALPHA"],
+    )
+    table.add_column(
+        f"Rate ({Balance.unit}/{Balance.get_unit(1)})",
+        justify="center",
+        style=COLOR_PALETTE["POOLS"]["RATE"],
+    )
+    table.add_column(
+        f"Fee ({Balance.get_unit(1)})",
+        justify="center",
+        style=COLOR_PALETTE["STAKE"]["STAKE_AMOUNT"],
+    )
+    table.add_column(
+        "Extrinsic Fee (τ)",
+        justify="center",
+        style=COLOR_PALETTE.STAKE.TAO,
+    )
+    table.add_column(
+        f"Received ({Balance.unit})",
+        justify="center",
+        style=COLOR_PALETTE["POOLS"]["TAO_EQUIV"],
+    )
+    # table.add_column(
+    #     "Slippage",
+    #     justify="center",
+    #     style=COLOR_PALETTE["STAKE"]["SLIPPAGE_PERCENT"],
+    # )
+
+    # Calculate total received
+    total_received_value = Balance(0)
+    for stake in stake_info:
+        if stake.stake.rao == 0:
+            continue
+
+        hotkey_display = hotkey_names.get(stake.hotkey_ss58, stake.hotkey_ss58)
+        subnet_info = all_sn_dynamic_info.get(stake.netuid)
+        stake_amount = stake.stake
+
+        try:
+            _ = subnet_info.price.tao
+            extrinsic_type = (
+                "unstake_all" if not unstake_all_alpha else "unstake_all_alpha"
             )
+            extrinsic_fee = await _get_extrinsic_fee(
+                extrinsic_type,
+                wallet,
+                subtensor,
+                hotkey_ss58=stake.hotkey_ss58,
+                proxy=proxy,
+            )
+            sim_swap = await subtensor.sim_swap(stake.netuid, 0, stake_amount.rao)
+            received_amount = sim_swap.tao_amount
+            if not proxy:
+                received_amount -= extrinsic_fee
+
+            if received_amount < Balance.from_tao(0):
+                print_error("Not enough Alpha to pay the transaction fee.")
+                continue
+        except (AttributeError, ValueError):
+            continue
+
+        total_received_value += received_amount
+
+        table.add_row(
+            str(stake.netuid),
+            hotkey_display,
+            str(stake_amount),
+            f"{float(subnet_info.price):.6f}"
+            + f"({Balance.get_unit(0)}/{Balance.get_unit(stake.netuid)})",
+            str(sim_swap.alpha_fee),
+            str(extrinsic_fee),
+            str(received_amount),
+        )
     console.print(table)
 
     console.print(

--- a/bittensor_cli/src/commands/stake/remove.py
+++ b/bittensor_cli/src/commands/stake/remove.py
@@ -124,6 +124,13 @@ async def unstake(
             identities=ck_hk_identities,
         )
 
+    hotkeys_existence = await subtensor.do_hotkeys_exist(
+        [x[1] for x in hotkeys_to_unstake_from], block_hash=chain_head
+    )
+    hotkeys_to_unstake_from = [
+        x for x in hotkeys_to_unstake_from if hotkeys_existence[x[1]] is True
+    ]
+
     with console.status(
         f"Retrieving stake data from {subtensor.network}...",
         spinner="earth",
@@ -334,7 +341,7 @@ async def unstake(
         with console.status(
             f"\n:satellite: Batching {total_ops} unstake operations..."
         ) as status:
-            batch_block_hash = await subtensor.substrate.get_chain_head()
+            batch_block_hash = chain_head
             current_balance = await subtensor.get_balance(
                 coldkey_ss58, block_hash=batch_block_hash
             )

--- a/tests/e2e_tests/test_unstaking.py
+++ b/tests/e2e_tests/test_unstaking.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os.path
 import re
 import pytest
 from bittensor_cli.src.bittensor.balances import Balance
@@ -89,8 +90,8 @@ def test_unstaking(local_chain, wallet_setup):
             "--no-prompt",
         ],
     )
-    assert "✅ Registered subnetwork with netuid: 2" in result.stdout
-    assert "Your extrinsic has been included" in result.stdout, result.stdout
+    assert "✅ Registered subnetwork with netuid: 2" in result.stdout, result.stderr
+    assert "Your extrinsic has been included" in result.stdout, result.stderr
 
     # Create second subnet (netuid = 3)
     result = exec_command_alice(
@@ -422,6 +423,17 @@ def test_unstaking(local_chain, wallet_setup):
         assert "✅ Finalized" in stake_result.stdout
         assert "Your extrinsic has been included" in stake_result.stdout
 
+    # add a dummy wallet to bob (hotkey and hotkeypub)
+    dummy_hk_pub = '{"ss58Address":"5GWN73LyFw8u5L38CHKh1EogaC4rbYUMPffrmU8PzPfK4oH3","accountId":"0xc482d28f38382438ea64652a6d26c1a6309cd8a91ef8e16af9c307238bea1b57","publicKey":"0xc482d28f38382438ea64652a6d26c1a6309cd8a91ef8e16af9c307238bea1b57"}'
+    with open(
+        os.path.join(wallet_path_bob, wallet_bob.name, "hotkeys", "dummypub.txt"), "w+"
+    ) as f:
+        f.write(dummy_hk_pub)
+    with open(
+        os.path.join(wallet_path_bob, wallet_bob.name, "hotkeys", "dummy"), "w+"
+    ) as f:
+        f.write(dummy_hk_pub)
+
     # Remove all stakes
     unstake_all = exec_command_bob(
         command="stake",
@@ -436,10 +448,16 @@ def test_unstaking(local_chain, wallet_setup):
             "--chain",
             "ws://127.0.0.1:9945",
             "--all",
+            "--all-hotkeys",
             "--no-prompt",
             "--era",
             "144",
         ],
+    )
+    print(unstake_all.stdout, unstake_all.stderr)
+    assert (
+        "Some hotkeys attempting to unstake are not present: 5GWN73LyFw8u5L38CHKh1EogaC4rbYUMPffrmU8PzPfK4oH3."
+        in unstake_all.stdout
     )
     assert "✅ Included: Successfully unstaked all stakes from" in unstake_all.stdout
     assert "Your extrinsic has been included" in unstake_all.stdout, unstake_all.stdout

--- a/tests/unit_tests/conftest.py
+++ b/tests/unit_tests/conftest.py
@@ -190,4 +190,10 @@ def mock_subtensor() -> MagicMock:
         return_value={"hotkeys": {}, "coldkeys": {}}
     )
     st.get_all_subnet_netuids = AsyncMock(return_value=[0, 1])
+
+    async def _do_hotkeys_exist(hotkeys_ss58, block_hash=None):
+        del block_hash
+        return {ss58: True for ss58 in hotkeys_ss58}
+
+    st.do_hotkeys_exist = AsyncMock(side_effect=_do_hotkeys_exist)
     return st


### PR DESCRIPTION
Complaint from a user that their batch unstake failed due to an issue where one of the keys was not actually existing on chain. This adds a catch for this situation. 

Applies the same logic to stake add to resolve #925 