### PR TITLE
Decode hotkey ss58 if bytes

### DIFF
--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -152,7 +152,10 @@ def get_hotkey_identity_name(
     """Return a hotkey display name from the V2 identity map, if present."""
     hotkey_identity = identities.get("hotkeys", {}).get(hotkey_ss58, {})
     identity_data = hotkey_identity.get("identity", {})
-    return identity_data.get("name") or identity_data.get("display") or None
+    if isinstance((id_name := identity_data.get("name")), list):
+        if len(id_name) != 0:
+            return bytes(id_name).decode("utf-8")
+    return identity_data.get("display") or None
 
 
 def get_coldkey_identity_name(

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -155,6 +155,8 @@ def get_hotkey_identity_name(
     if isinstance((id_name := identity_data.get("name")), list):
         if len(id_name) != 0:
             return bytes(id_name).decode("utf-8")
+    elif isinstance(id_name, str):
+        return id_name
     return identity_data.get("display") or None
 
 


### PR DESCRIPTION
If we grab the hotkey name from identity["name"], it's always encoded as bytes (from the chain) rather than a string, which can raise this error:
❌ An unknown error has occurred: unable to render list; a string or other renderable object is required

This handles that.