### PR TITLE
fix(axon): validate ip_type and ip-version match before submitting set_axon

### DIFF
--- a/bittensor_cli/src/bittensor/extrinsics/serving.py
+++ b/bittensor_cli/src/bittensor/extrinsics/serving.py
@@ -5,6 +5,7 @@ Extrinsics for serving operations (axon management).
 import typing
 from typing import Optional
 
+import netaddr
 from bittensor_wallet import Wallet
 
 from bittensor_cli.src.bittensor.utils import (
@@ -190,8 +191,6 @@ async def set_axon_extrinsic(
     # 32-bit when interpreted as ip_type=4 and 128-bit when interpreted as
     # ip_type=6, so the wrong combination yields an unreachable axon).
     try:
-        import netaddr
-
         parsed_ip = netaddr.IPAddress(ip)
         ip_int = int(parsed_ip)
     except Exception as e:

--- a/bittensor_cli/src/bittensor/extrinsics/serving.py
+++ b/bittensor_cli/src/bittensor/extrinsics/serving.py
@@ -176,11 +176,33 @@ async def set_axon_extrinsic(
     if not (0 <= port <= 65535):
         return False, f"Invalid port number: {port}. Must be between 0 and 65535.", None
 
-    # Validate IP address
+    # Validate ip_type
+    if ip_type not in (4, 6):
+        return (
+            False,
+            f"Invalid ip_type: {ip_type}. Must be 4 (IPv4) or 6 (IPv6).",
+            None,
+        )
+
+    # Validate IP address and that its version matches the supplied ip_type.
+    # netaddr.IPAddress auto-detects v4 vs v6 from the string, so a mismatch
+    # would otherwise be silently submitted on-chain (the integer is
+    # 32-bit when interpreted as ip_type=4 and 128-bit when interpreted as
+    # ip_type=6, so the wrong combination yields an unreachable axon).
     try:
-        ip_int = ip_to_int(ip)
+        import netaddr
+
+        parsed_ip = netaddr.IPAddress(ip)
+        ip_int = int(parsed_ip)
     except Exception as e:
         return False, f"Invalid IP address: {ip}. Error: {str(e)}", None
+
+    if parsed_ip.version != ip_type:
+        return (
+            False,
+            f"IP {ip} is IPv{parsed_ip.version}, but --ip-type was set to {ip_type}.",
+            None,
+        )
 
     # Unlock the hotkey
     if not (


### PR DESCRIPTION
## Summary

- Reject `ip_type` values outside `{4, 6}` in `set_axon_extrinsic` with a clear CLI error before composing the extrinsic
- Reject IPs whose parsed version (via `netaddr.IPAddress`) disagrees with the supplied `ip_type` (e.g. `--ip 2001:db8::1 --ip-type 4` or `--ip 192.168.1.1 --ip-type 6`)
- Mirrors the existing port-validation pattern already in the same function
- `reset_axon_extrinsic` is unaffected — it uses hardcoded `ip="0.0.0.0"` with `ip_type=4`

## Background

`set_axon_extrinsic` validates `port` and that the IP string parses, but does not validate `ip_type` or that the IP's version matches `ip_type`. Because `netaddr.IPAddress` auto-detects the version from the input string, a mismatched `--ip` / `--ip-type` combination is silently encoded into an integer (32-bit if v4, 128-bit if v6) and submitted on-chain. Validators reading the axon then interpret the stored integer using the on-chain `ip_type` field, get a garbage address from the wrong-width int, and the miner is registered but unreachable — with no error surfaced to the user.

## Related Issues

N/A — code review.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested — `btcli axon set` with `--ip-type 5`, with v6 IP and `--ip-type 4`, and with v4 IP and `--ip-type 6` all now exit with a clear error before any extrinsic is composed; matching `--ip` / `--ip-type` proceeds unchanged

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Changes are documented (if applicable)
