### PR TITLE
Support New Hyperparams

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -6897,6 +6897,11 @@ class CLIManager:
         param_value: Optional[str] = typer.Option(
             "", "--value", help="Value to set the hyperparameter to."
         ),
+        normalize_value: bool = typer.Option(
+            False,
+            "--normalize",
+            help="Whether to accept input as the normalized value.",
+        ),
         proxy: Optional[str] = Options.proxy,
         prompt: bool = Options.prompt,
         decline: bool = Options.decline,
@@ -7108,10 +7113,12 @@ class CLIManager:
                     "Param value not supplied with `--no-prompt` flag. Cannot continue."
                 )
                 return False
-            if HYPERPARAMS.get(param_name):
+            if not normalize_value and HYPERPARAMS.get(param_name):
                 param_value = Prompt.ask(
                     f"Enter the new value for [{COLORS.G.SUBHEAD}]{param_name}[/{COLORS.G.SUBHEAD}] "
-                    f"in the VALUE column format"
+                    f"in the VALUE column format. \n"
+                    f"Tip: to enter the normalized value instead, run this command with "
+                    f"{arg__('--normalize')} instead."
                 )
             else:
                 param_value = None
@@ -7137,6 +7144,7 @@ class CLIManager:
                         proxy=proxy,
                         param_name=param_name,
                         param_value=param_value,
+                        normalize=normalize_value,
                         prompt=prompt,
                         json_output=json_output,
                     )
@@ -7174,6 +7182,7 @@ class CLIManager:
                     proxy=proxy,
                     param_name=param_name,
                     param_value=param_value,
+                    normalize=normalize_value,
                     prompt=prompt,
                     json_output=json_output,
                 )

--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -650,6 +650,8 @@ HYPERPARAMS = {
     "subnet_is_active": ("", RootSudoOnly.FALSE),  # Set via btcli subnets start
     "yuma_version": ("", RootSudoOnly.FALSE),  # Related to yuma3_enabled
     "max_allowed_uids": ("sudo_set_max_allowed_uids", RootSudoOnly.FALSE),
+    "burn_increase_mult": ("sudo_set_burn_increase_mult", RootSudoOnly.FALSE),
+    "burn_half_life": ("sudo_set_burn_half_life", RootSudoOnly.FALSE),
 }
 
 HYPERPARAMS_MODULE = {

--- a/bittensor_cli/src/bittensor/chain_data.py
+++ b/bittensor_cli/src/bittensor/chain_data.py
@@ -4,6 +4,7 @@ from enum import Enum
 from typing import Optional, Any, Union
 
 import netaddr
+from scalecodec.utils.math import FixedPoint
 from scalecodec.utils.ss58 import ss58_encode
 
 from bittensor_cli.src.bittensor.balances import Balance, fixed_to_float
@@ -185,11 +186,16 @@ class SubnetHyperparameters(InfoBase):
     transfers_enabled: bool
     bonds_reset_enabled: bool
     user_liquidity_enabled: bool
+    burn_increase_mult: FixedPoint
+    burn_half_life: int
 
     @classmethod
     def _fix_decoded(
-        cls, decoded: Union[dict, "SubnetHyperparameters"]
+        cls,
+        decoded: Union[dict, "SubnetHyperparameters"],
     ) -> "SubnetHyperparameters":
+        burn_increase_mult: FixedPoint = decoded["burn_increase_mult"]
+        burn_half_life: int = decoded["burn_half_life"]
         return cls(
             activity_cutoff=decoded["activity_cutoff"],
             adjustment_alpha=decoded["adjustment_alpha"],
@@ -226,6 +232,8 @@ class SubnetHyperparameters(InfoBase):
             weights_rate_limit=decoded["weights_rate_limit"],
             weights_version=decoded["weights_version"],
             yuma_version=decoded["yuma_version"],
+            burn_increase_mult=burn_increase_mult,
+            burn_half_life=burn_half_life,
         )
 
 

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -1364,16 +1364,29 @@ class SubtensorInterface:
         Understanding the hyperparameters is crucial for comprehending how subnets are configured and
         managed, and how they interact with the network's consensus and incentive mechanisms.
         """
-        result = await self.query_runtime_api(
-            runtime_api="SubnetInfoRuntimeApi",
-            method="get_subnet_hyperparams_v2",
-            params=[netuid],
-            block_hash=block_hash,
+        result, burn_increase_mult, burn_half_life = await asyncio.gather(
+            self.query_runtime_api(
+                runtime_api="SubnetInfoRuntimeApi",
+                method="get_subnet_hyperparams_v2",
+                params=[netuid],
+                block_hash=block_hash,
+            ),
+            self.substrate.query(
+                "SubtensorModule", "BurnIncreaseMult", [netuid], block_hash=block_hash
+            ),
+            self.substrate.query(
+                "SubtensorModule", "BurnHalfLife", [netuid], block_hash=block_hash
+            ),
         )
         if not result:
             return []
 
-        return SubnetHyperparameters.from_any(result)
+        additional = {
+            "burn_increase_mult": burn_increase_mult.value,
+            "burn_half_life": burn_half_life.value,
+        }
+
+        return SubnetHyperparameters.from_any(result | additional)
 
     async def get_subnet_mechanisms(
         self, netuid: int, block_hash: Optional[str] = None

--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -1364,6 +1364,8 @@ class SubtensorInterface:
         Understanding the hyperparameters is crucial for comprehending how subnets are configured and
         managed, and how they interact with the network's consensus and incentive mechanisms.
         """
+        if block_hash is None:
+            block_hash = await self.substrate.get_chain_head()
         result, burn_increase_mult, burn_half_life = await asyncio.gather(
             self.query_runtime_api(
                 runtime_api="SubnetInfoRuntimeApi",

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -7,6 +7,7 @@ import sqlite3
 import sys
 import webbrowser
 from contextlib import contextmanager
+from decimal import Decimal
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Collection, Optional, Union, Callable, Generator
 from urllib.parse import urlparse
@@ -301,6 +302,14 @@ def u64_normalized_float(x: int) -> float:
 def string_to_u64(value: str) -> int:
     """Converts a string to u64"""
     return float_to_u64(float(value))
+
+
+def string_to_u64f64(value: str) -> int:
+    """Converts a string to a U64F64 fixed-point raw u128 value."""
+    d = Decimal(value)
+    if not (0 <= d < 2**64):
+        raise ValueError("Input value must be in the range [0, 2**64)")
+    return int(d * (Decimal(2) ** 64))
 
 
 def float_to_u64(value: float) -> int:

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -337,6 +337,19 @@ def string_to_u16(value: str) -> int:
     return float_to_u16(float(value))
 
 
+def string_to_i16(value: str) -> int:
+    return float_to_i16(float(value))
+
+
+def float_to_i16(value: float) -> int:
+    """Converts a float to a 16-bit signed integer"""
+    if not (-1 <= value <= 1):
+        raise ValueError("Input value must be between -1 and 1")
+
+    i16_max = 32767
+    return int(value * i16_max)
+
+
 def float_to_u16(value: float) -> int:
     # Ensure the input is within the expected range
     if not (0 <= value <= 1):

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -338,6 +338,7 @@ def string_to_u16(value: str) -> int:
 
 
 def string_to_i16(value: str) -> int:
+    """Converts a stringified float to a u16 int"""
     return float_to_i16(float(value))
 
 

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -33,7 +33,7 @@ import typer
 
 from bittensor_cli.src.bittensor.balances import Balance
 from bittensor_cli.src import defaults, Constants
-
+from scalecodec.utils.math import fixed_to_float
 
 if TYPE_CHECKING:
     from bittensor_cli.src.bittensor.chain_data import SubnetHyperparameters
@@ -934,6 +934,8 @@ def normalize_hyperparameters(
         "alpha_sigmoid_steepness": u16_normalized_float,
         "min_burn": Balance.from_rao,
         "max_burn": Balance.from_rao,
+        "burn_increase_mult": fixed_to_float,
+        "burn_half_life": u16_normalized_float,
     }
 
     normalized_values: list[tuple[str, str, str]] = []

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -37,6 +37,7 @@ from bittensor_cli.src.bittensor.utils import (
     get_hotkey_pub_ss58,
     print_extrinsic_id,
     get_hotkey_identity_name,
+    string_to_u64f64,
 )
 
 if TYPE_CHECKING:
@@ -356,7 +357,8 @@ def search_metadata(
                     f"Enter a value for field '{arg_name}' with type '{arg_type_output[type_]}': "
                 )
             return arg_types[type_](val)
-        except ValueError:
+        except ValueError as e:
+            print_error(f"Error: {e}")
             return type_converter_with_retry(type_, None, arg_name)
         except KeyError:
             print_error(
@@ -364,14 +366,21 @@ def search_metadata(
                 "You will be unable to set this parameter via this command.\n"
                 "Some hyperparams must be set by their dedicated command, such as `btcli subnets mech`"
             )
+            raise KeyError
 
     arg_types = {
         "bool": string_to_bool,
         "u16": string_to_u16,
         "u64": string_to_u64,
         "MechId": int,
+        "U64F64": string_to_u64f64,
     }
-    arg_type_output = {"bool": "bool", "u16": "float", "u64": "float"}
+    arg_type_output = {
+        "bool": "bool",
+        "u16": "float",
+        "u64": "float",
+        "U64F64": "decimal",
+    }
 
     call_crafter = {"netuid": netuid}
 
@@ -383,15 +392,23 @@ def search_metadata(
             call_args = [arg for arg in call.args if arg.value["name"] != "netuid"]
             if len(call_args) == 1:
                 arg = call_args[0].value
-                call_crafter[arg["name"]] = type_converter_with_retry(
-                    arg["typeName"], value, arg["name"]
-                )
+                try:
+                    call_crafter[arg["name"]] = type_converter_with_retry(
+                        arg["typeName"], value, arg["name"]
+                    )
+                except KeyError:
+                    return False, {"error": "Unable to set value for hyperparameter"}
             else:
                 for arg_ in call_args:
                     arg = arg_.value
-                    call_crafter[arg["name"]] = type_converter_with_retry(
-                        arg["typeName"], None, arg["name"]
-                    )
+                    try:
+                        call_crafter[arg["name"]] = type_converter_with_retry(
+                            arg["typeName"], None, arg["name"]
+                        )
+                    except KeyError:
+                        return False, {
+                            "error": "Unable to set value for hyperparameter"
+                        }
             return True, call_crafter
     else:
         return False, None
@@ -554,7 +571,10 @@ async def set_hyperparameter_extrinsic(
         )
         extrinsic = parameter
         if not arbitrary_extrinsic:
-            err_msg = "Invalid hyperparameter specified."
+            if call_params:
+                err_msg = call_params["error"]
+            else:
+                err_msg = "Invalid hyperparameter specified."
             print_error(err_msg)
             return False, err_msg, None
     if sudo_ is RootSudoOnly.TRUE and prompt:

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -374,12 +374,14 @@ def search_metadata(
         "u64": string_to_u64,
         "MechId": int,
         "U64F64": string_to_u64f64,
+        "TaoBalance": lambda x: Balance.from_tao(float(x)).rao,
     }
     arg_type_output = {
         "bool": "bool",
         "u16": "float",
         "u64": "float",
         "U64F64": "decimal",
+        "TaoBalance": "Tao (float)",
     }
 
     call_crafter = {"netuid": netuid}

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -524,6 +524,7 @@ async def set_hyperparameter_extrinsic(
     proxy: Optional[str],
     parameter: str,
     value: Optional[Union[str, float, list[float]]],
+    normalize: bool,
     wait_for_inclusion: bool = False,
     wait_for_finalization: bool = True,
     prompt: bool = True,
@@ -538,6 +539,7 @@ async def set_hyperparameter_extrinsic(
     :param proxy: Optional proxy to use for this extrinsic submission.
     :param parameter: Hyperparameter name.
     :param value: New hyperparameter value.
+    :param normalize: Normalize hyperparameter value or not.
     :param wait_for_inclusion: If set, waits for the extrinsic to enter a block before returning `True`, or returns
                                `False` if the extrinsic fails to enter the block within the timeout.
     :param wait_for_finalization: If set, waits for the extrinsic to be finalized on the chain before returning `True`,
@@ -570,6 +572,9 @@ async def set_hyperparameter_extrinsic(
 
     extrinsic, sudo_ = HYPERPARAMS.get(parameter, ("", RootSudoOnly.FALSE))
     call_params = {"netuid": netuid}
+    if normalize:
+        parameter = extrinsic
+        extrinsic = None
     if not extrinsic:
         arbitrary_extrinsic, call_params = search_metadata(
             parameter, value, netuid, subtensor.substrate.metadata
@@ -1020,6 +1025,7 @@ async def sudo_set_hyperparameter(
     proxy: Optional[str],
     param_name: str,
     param_value: Optional[str],
+    normalize: bool,
     prompt: bool,
     json_output: bool,
 ) -> tuple[bool, str, Optional[str]]:
@@ -1043,7 +1049,14 @@ async def sudo_set_hyperparameter(
     if json_output:
         prompt = False
     success, err_msg, ext_id = await set_hyperparameter_extrinsic(
-        subtensor, wallet, netuid, proxy, param_name, value, prompt=prompt
+        subtensor,
+        wallet,
+        netuid,
+        proxy,
+        param_name,
+        value,
+        normalize=normalize,
+        prompt=prompt,
     )
     if json_output:
         return success, err_msg, ext_id

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -38,6 +38,7 @@ from bittensor_cli.src.bittensor.utils import (
     print_extrinsic_id,
     get_hotkey_identity_name,
     string_to_u64f64,
+    float_to_u16,
 )
 
 if TYPE_CHECKING:
@@ -53,7 +54,7 @@ DEFAULT_PALLET = "AdminUtils"
 
 
 def allowed_value(
-    param: str, value: Union[str, bool]
+    param: str, value: str | bool, normalize: bool
 ) -> tuple[bool, Union[str, list[float], float, bool]]:
     """
     Check the allowed values on hyperparameters. Return False if value is out of bounds.
@@ -72,18 +73,32 @@ def allowed_value(
                 alpha_low = float(alpha_low_str)
 
                 # Check alpha_high value
-                if alpha_high <= 52428 or alpha_high >= 65535:
-                    return (
-                        False,
-                        f"between 52428 and 65535 for alpha_high (but is {alpha_high})",
-                    )
+                if normalize:
+                    if alpha_high <= 0.8 or alpha_high >= 1.0:
+                        return (
+                            False,
+                            f"between 0.8 and 1.0 for alpha_high (but is {alpha_high})",
+                        )
+                else:
+                    if alpha_high <= 52428 or alpha_high >= 65535:
+                        return (
+                            False,
+                            f"between 52428 and 65535 for alpha_high (but is {alpha_high})",
+                        )
 
                 # Check alpha_low value
-                if alpha_low < 0 or alpha_low > 52428:
-                    return (
-                        False,
-                        f"between 0 and 52428 for alpha_low (but is {alpha_low})",
-                    )
+                if normalize:
+                    if alpha_low < 0.0 or alpha_low > 0.8:
+                        return (
+                            False,
+                            f"between 0.0 and 0.8 for alpha_low (but is {alpha_low})",
+                        )
+                else:
+                    if alpha_low < 0 or alpha_low > 52428:
+                        return (
+                            False,
+                            f"between 0 and 52428 for alpha_low (but is {alpha_low})",
+                        )
 
                 return True, [alpha_low, alpha_high]
     except ValueError:
@@ -574,7 +589,7 @@ async def set_hyperparameter_extrinsic(
 
     extrinsic, sudo_ = HYPERPARAMS.get(parameter, ("", RootSudoOnly.FALSE))
     call_params = {"netuid": netuid}
-    if normalize:
+    if normalize and parameter != "alpha_values":
         parameter = extrinsic
         extrinsic = None
     if not extrinsic:
@@ -1032,7 +1047,7 @@ async def sudo_set_hyperparameter(
     json_output: bool,
 ) -> tuple[bool, str, Optional[str]]:
     """Set subnet hyperparameters."""
-    is_allowed_value, value = allowed_value(param_name, param_value)
+    is_allowed_value, value = allowed_value(param_name, param_value, normalize)
     if not is_allowed_value:
         err_msg = (
             f"Hyperparameter [dark_orange]{param_name}[/dark_orange] value is not within bounds. "
@@ -1050,6 +1065,8 @@ async def sudo_set_hyperparameter(
         return False, err_msg, None
     if json_output:
         prompt = False
+    if param_name == "alpha_values":
+        value = [float_to_u16(value[0]), float_to_u16(value[1])]
     success, err_msg, ext_id = await set_hyperparameter_extrinsic(
         subtensor,
         wallet,

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -552,10 +552,15 @@ async def set_hyperparameter_extrinsic(
     """
     print_verbose("Confirming subnet owner")
     coldkey_ss58 = proxy or wallet.coldkeypub.ss58_address
+    block_hash = (
+        subtensor.substrate.last_block_hash
+        or await subtensor.substrate.get_chain_head()
+    )
     subnet_owner = await subtensor.query(
         module="SubtensorModule",
         storage_function="SubnetOwner",
         params=[netuid],
+        block_hash=block_hash,
     )
 
     if not (ulw := unlock_key(wallet)).success:
@@ -591,7 +596,7 @@ async def set_hyperparameter_extrinsic(
 
     if not arbitrary_extrinsic:
         extrinsic_params = await substrate.get_metadata_call_function(
-            module_name=pallet, call_function_name=extrinsic
+            module_name=pallet, call_function_name=extrinsic, block_hash=block_hash
         )
 
         # if input value is a list, iterate through the list and assign values
@@ -626,10 +631,14 @@ async def set_hyperparameter_extrinsic(
         call_module=pallet,
         call_function=extrinsic,
         call_params=call_params,
+        block_hash=block_hash,
     )
     if sudo_ is RootSudoOnly.TRUE:
         call = await substrate.compose_call(
-            call_module="Sudo", call_function="sudo", call_params={"call": call_}
+            call_module="Sudo",
+            call_function="sudo",
+            call_params={"call": call_},
+            block_hash=block_hash,
         )
     elif sudo_ is RootSudoOnly.COMPLICATED:
         if not prompt:
@@ -647,6 +656,7 @@ async def set_hyperparameter_extrinsic(
                 call_module="Sudo",
                 call_function="sudo",
                 call_params={"call": call_},
+                block_hash=block_hash,
             )
         else:
             if subnet_owner != coldkey_ss58:

--- a/bittensor_cli/src/commands/sudo.py
+++ b/bittensor_cli/src/commands/sudo.py
@@ -39,6 +39,7 @@ from bittensor_cli.src.bittensor.utils import (
     get_hotkey_identity_name,
     string_to_u64f64,
     float_to_u16,
+    string_to_i16,
 )
 
 if TYPE_CHECKING:
@@ -368,10 +369,17 @@ def search_metadata(
     def type_converter_with_retry(type_, val, arg_name):
         try:
             if val is None:
+                if arg_name in do_not_convert:
+                    output_type = do_not_convert[arg_name].__name__
+                else:
+                    output_type = arg_type_output[type_]
                 val = input(
-                    f"Enter a value for field '{arg_name}' with type '{arg_type_output[type_]}': "
+                    f"Enter a value for field '{arg_name}' with type '{output_type}': "
                 )
-            return arg_types[type_](val)
+            if arg_name in do_not_convert:
+                return do_not_convert[arg_name](val)
+            else:
+                return arg_types[type_](val)
         except ValueError as e:
             print_error(f"Error: {e}")
             return type_converter_with_retry(type_, None, arg_name)
@@ -383,9 +391,26 @@ def search_metadata(
             )
             raise KeyError
 
+    do_not_convert = {
+        "max_registrations_per_block": int,
+        "immunity_period": int,
+        "commit_reveal_period": int,
+        "adjustment_interval": int,
+        "max_validators": int,
+        "min_allowed_weights": int,
+        "rho": int,
+        "serving_rate_limit": int,
+        "target_regs_per_interval": int,
+        "tempo": int,
+        "weights_rate_limit": int,
+        "weights_version": int,
+        "yuma_version": int,
+    }
+
     arg_types = {
         "bool": string_to_bool,
         "u16": string_to_u16,
+        "i16": string_to_i16,
         "u64": string_to_u64,
         "MechId": int,
         "U64F64": string_to_u64f64,
@@ -394,6 +419,7 @@ def search_metadata(
     arg_type_output = {
         "bool": "bool",
         "u16": "float",
+        "i16": "float (signed)",
         "u64": "float",
         "U64F64": "decimal",
         "TaoBalance": "Tao (float)",

--- a/tests/e2e_tests/test_hyperparams_setting.py
+++ b/tests/e2e_tests/test_hyperparams_setting.py
@@ -102,7 +102,13 @@ def test_hyperparams_setting(local_chain, wallet_setup):
         )
 
     # Skip parameters that cannot be set with --no-prompt
-    SKIP_PARAMS = {"alpha_high", "alpha_low", "subnet_is_active", "yuma_version"}
+    SKIP_PARAMS = {
+        "alpha_high",
+        "alpha_low",
+        "subnet_is_active",
+        "yuma_version",
+        "burn_increase_mult",
+    }
 
     for key, (_, sudo_only) in HYPERPARAMS.items():
         print(f"key: {key}, sudo_only: {sudo_only}")

--- a/tests/e2e_tests/test_hyperparams_setting.py
+++ b/tests/e2e_tests/test_hyperparams_setting.py
@@ -174,6 +174,40 @@ def test_hyperparams_setting(local_chain, wallet_setup):
     cmd_json = json.loads(cmd.stdout)
     assert cmd_json["success"] is True, (cmd.stdout, cmd_json)
     assert isinstance(cmd_json["extrinsic_identifier"], str)
+    # also test normalization
+    param_value_map = [
+        ("max_burn", "110"),
+        ("burn_half_life", "0.15"),
+        ("burn_increase_mult", "1.26"),
+        ("max_regs_per_block", "2"),  # already normalized
+    ]
+    for param, val in param_value_map:
+        cmd = exec_command_alice(
+            command="sudo",
+            sub_command="set",
+            extra_args=[
+                "--wallet-path",
+                wallet_path_alice,
+                "--network",
+                "ws://127.0.0.1:9945",
+                "--wallet-name",
+                wallet_alice.name,
+                "--wallet-hotkey",
+                wallet_alice.hotkey_str,
+                "--netuid",
+                netuid,
+                "--json-out",
+                "--no-prompt",
+                "--param",
+                param,
+                "--value",
+                val,
+                "--normalize",
+            ],
+        )
+        cmd_json = json.loads(cmd.stdout)
+        assert cmd_json["success"] is True, (cmd.stdout, cmd_json)
+        assert isinstance(cmd_json["extrinsic_identifier"], str)
     print("Successfully set hyperparameters")
     print("Testing trimming UIDs")
     cmd = exec_command_alice(

--- a/tests/unit_tests/test_sudo_hyperparameter_permissions.py
+++ b/tests/unit_tests/test_sudo_hyperparameter_permissions.py
@@ -40,6 +40,7 @@ async def test_max_burn_no_prompt_owner_uses_owner_path(
             wait_for_inclusion=False,
             wait_for_finalization=False,
             prompt=False,
+            normalize=False,
         )
 
     assert success is True
@@ -94,6 +95,7 @@ async def test_max_burn_no_prompt_non_owner_uses_sudo_path(
             wait_for_inclusion=False,
             wait_for_finalization=False,
             prompt=False,
+            normalize=False,
         )
 
     assert success is True
@@ -154,6 +156,7 @@ async def test_max_burn_interactive_owner_chooses_non_sudo_path(
             prompt=True,
             decline=False,
             quiet=True,
+            normalize=False,
         )
 
     assert success is True
@@ -205,6 +208,7 @@ async def test_max_burn_interactive_non_owner_chooses_non_sudo_errors(
             prompt=True,
             decline=False,
             quiet=True,
+            normalize=False,
         )
 
     assert success is False

--- a/tests/unit_tests/test_sudo_hyperparameter_permissions.py
+++ b/tests/unit_tests/test_sudo_hyperparameter_permissions.py
@@ -50,6 +50,7 @@ async def test_max_burn_no_prompt_owner_uses_owner_path(
         call_module="AdminUtils",
         call_function="sudo_set_max_burn",
         call_params={"netuid": 1, "max_burn": "10000000000"},
+        block_hash=mock_subtensor.substrate.last_block_hash,
     )
     mock_subtensor.sign_and_send_extrinsic.assert_awaited_once_with(
         direct_call,
@@ -106,11 +107,13 @@ async def test_max_burn_no_prompt_non_owner_uses_sudo_path(
         "call_module": "AdminUtils",
         "call_function": "sudo_set_max_burn",
         "call_params": {"netuid": 1, "max_burn": "10000000000"},
+        "block_hash": mock_subtensor.substrate.last_block_hash,
     }
     assert mock_subtensor.substrate.compose_call.await_args_list[1].kwargs == {
         "call_module": "Sudo",
         "call_function": "sudo",
         "call_params": {"call": direct_call},
+        "block_hash": mock_subtensor.substrate.last_block_hash,
     }
     mock_subtensor.sign_and_send_extrinsic.assert_awaited_once_with(
         sudo_call,
@@ -166,6 +169,7 @@ async def test_max_burn_interactive_owner_chooses_non_sudo_path(
         call_module="AdminUtils",
         call_function="sudo_set_max_burn",
         call_params={"netuid": 1, "max_burn": "10000000000"},
+        block_hash=mock_subtensor.substrate.last_block_hash,
     )
     mock_subtensor.sign_and_send_extrinsic.assert_awaited_once_with(
         direct_call,
@@ -218,5 +222,6 @@ async def test_max_burn_interactive_non_owner_chooses_non_sudo_errors(
         call_module="AdminUtils",
         call_function="sudo_set_max_burn",
         call_params={"netuid": 1, "max_burn": "10000000000"},
+        block_hash=mock_subtensor.substrate.last_block_hash,
     )
     mock_subtensor.sign_and_send_extrinsic.assert_not_awaited()


### PR DESCRIPTION
Adds support for setting U64F64 fixed point hyperparam values (such as in sudo_set_burn_increase_mult)

Also better output for why things fail: i.e. you entered `15` when it expects a value between 0 and 1.

Allows passing the `--normalize` flag to `sudo set` which allows the user to enter the normalized values (usually floats)