### PR TITLE
fix(cli): exit non-zero on validation and lookup errors

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -585,7 +585,7 @@ def parse_mnemonic(mnemonic: str) -> str:
         )
         if int(items[0][0]) != 1:
             print_error("Numbered mnemonics must begin with 1")
-            raise typer.Exit()
+            raise typer.Exit(1)
         if [int(x[0]) for x in items] != list(
             range(int(items[0][0]), int(items[-1][0]) + 1)
         ):
@@ -593,7 +593,7 @@ def parse_mnemonic(mnemonic: str) -> str:
                 "Missing or duplicate numbers in a numbered mnemonic. "
                 "Double-check your numbered mnemonics and try again."
             )
-            raise typer.Exit()
+            raise typer.Exit(1)
         response = " ".join(item[1] for item in items)
     else:
         response = mnemonic
@@ -639,7 +639,7 @@ def get_creation_data(
     if json_path:
         if not os.path.exists(json_path):
             print_error(f"The JSON file '{json_path}' does not exist.")
-            raise typer.Exit()
+            raise typer.Exit(1)
 
     if json_path and not json_password:
         json_password = Prompt.ask(
@@ -747,7 +747,7 @@ def debug_callback(value: bool) -> None:
                 f"file was created using the {arg__('BTCLI_DEBUG_FILE')} environment variable, please set the value for"
                 f" the same location, and re-run this {arg__('btcli --debug')} command."
             )
-            raise typer.Exit()
+            raise typer.Exit(1)
         save_file_loc_ = Prompt.ask(
             "Enter the file location to save the debug log for the previous command.",
             default="~/.bittensor/debug-export",
@@ -1638,7 +1638,7 @@ class CLIManager:
             )
         if quiet and verbose:
             print_error("Cannot specify both `--quiet` and `--verbose`")
-            raise typer.Exit()
+            raise typer.Exit(1)
         if json_output and verbose:
             verbosity_console_handler(3)
         elif json_output or quiet:
@@ -1837,7 +1837,7 @@ class CLIManager:
                             raise typer.Exit()
                 else:
                     print_error(f"{error}")
-                    raise typer.Exit()
+                    raise typer.Exit(1)
 
         for arg, val in args.items():
             if val is not None:
@@ -2028,7 +2028,7 @@ class CLIManager:
             print_error(
                 f"Proxy {name} already exists. Use `btcli config update-proxy` to update it."
             )
-            raise typer.Exit()
+            raise typer.Exit(1)
         proxy_type_val: str
         if isinstance(proxy_type, ProxyType):
             proxy_type_val = proxy_type.value
@@ -2439,7 +2439,7 @@ class CLIManager:
 
         if mechanism_count is None or mechanism_count <= 0:
             print_error(f"Subnet {netuid} does not exist.")
-            raise typer.Exit()
+            raise typer.Exit(1)
 
         if mechanism_id is not None:
             if mechanism_id < 0 or mechanism_id >= mechanism_count:
@@ -2447,7 +2447,7 @@ class CLIManager:
                     f"Mechanism ID {mechanism_id} is out of range for subnet {netuid}. "
                     f"Valid range: [bold cyan]0 to {mechanism_count - 1}[/bold cyan]."
                 )
-                raise typer.Exit()
+                raise typer.Exit(1)
             return mechanism_id
 
         if mechanism_count == 1:
@@ -2546,14 +2546,14 @@ class CLIManager:
                     f"Error: Wallet does not exist. \n"
                     f"Please verify your wallet information: {wallet}"
                 )
-                raise typer.Exit()
+                raise typer.Exit(1)
 
             if validate == WV.WALLET_AND_HOTKEY and not valid[1]:
                 print_error(
                     f"Error: Wallet '{wallet.name}' exists but the hotkey '{wallet.hotkey_str}' does not. \n"
                     f"Please verify your wallet information: {wallet}"
                 )
-                raise typer.Exit()
+                raise typer.Exit(1)
         if return_wallet_and_hotkey:
             valid = utils.is_valid_wallet(wallet)
             if valid[1]:
@@ -2671,7 +2671,7 @@ class CLIManager:
             print_error(
                 "You have specified both the inclusion and exclusion options. Only one of these options is allowed currently."
             )
-            raise typer.Exit()
+            raise typer.Exit(1)
 
         if netuids:
             netuids = parse_to_list(
@@ -2781,7 +2781,7 @@ class CLIManager:
         """
         if not is_valid_ss58_address(destination_ss58_address):
             print_error("You have entered an incorrect ss58 address. Please try again.")
-            raise typer.Exit()
+            raise typer.Exit(1)
 
         self.verbosity_handler(quiet, verbose, json_output, prompt)
         proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
@@ -3815,7 +3815,7 @@ class CLIManager:
             if valid_ss58s:
                 ss58_addresses = valid_ss58s
             else:
-                raise typer.Exit()
+                raise typer.Exit(1)
         else:
             if wallet_name:
                 coldkey_or_ss58 = wallet_name
@@ -3838,7 +3838,7 @@ class CLIManager:
                 if valid_ss58s:
                     ss58_addresses = valid_ss58s
                 else:
-                    raise typer.Exit()
+                    raise typer.Exit(1)
             else:
                 wallet_name = (
                     coldkey_or_ss58_list[0] if coldkey_or_ss58_list else wallet_name
@@ -3897,7 +3897,7 @@ class CLIManager:
             "This command is currently disabled as it used external APIs which are no longer "
             "feasible; meanwhile a chain native data fetching solution is being investigated."
         )
-        raise typer.Exit()
+        raise typer.Exit(1)
 
         self.verbosity_handler(quiet, verbose, False, False)
         wallet = self.wallet_ask(
@@ -4066,7 +4066,7 @@ class CLIManager:
             if coldkey_ss58:
                 if not is_valid_ss58_address(coldkey_ss58):
                     print_error("You entered an invalid ss58 address")
-                    raise typer.Exit()
+                    raise typer.Exit(1)
             else:
                 coldkey_or_ss58 = Prompt.ask(
                     "Enter the [blue]wallet name[/blue] or [blue]coldkey ss58 address[/blue]",
@@ -4568,7 +4568,7 @@ class CLIManager:
         if coldkey_ss58:
             if not is_valid_ss58_address(coldkey_ss58):
                 print_error("You entered an invalid ss58 address")
-                raise typer.Exit()
+                raise typer.Exit(1)
         else:
             if wallet_name:
                 coldkey_or_ss58 = wallet_name
@@ -4718,7 +4718,7 @@ class CLIManager:
         if coldkey_ss58:
             if not is_valid_ss58_address(coldkey_ss58):
                 print_error("You entered an invalid ss58 address")
-                raise typer.Exit()
+                raise typer.Exit(1)
         else:
             if wallet_name:
                 coldkey_or_ss58 = wallet_name
@@ -5032,12 +5032,12 @@ class CLIManager:
 
             if amount <= 0:
                 print_error(f"You entered an incorrect stake amount: {amount}")
-                raise typer.Exit()
+                raise typer.Exit(1)
             if Balance.from_tao(amount) > free_balance:
                 print_error(
                     f"You dont have enough balance to stake. Current free Balance: {free_balance}."
                 )
-                raise typer.Exit()
+                raise typer.Exit(1)
         logger.debug(
             "args:\n"
             f"network: {network}\n"
@@ -5551,7 +5551,7 @@ class CLIManager:
                 print_error(
                     "Invalid destination hotkey ss58 address. Please enter a valid ss58 address."
                 )
-                raise typer.Exit()
+                raise typer.Exit(1)
         else:
             if is_valid_ss58_address(destination_hotkey):
                 destination_hotkey = destination_hotkey
@@ -5559,7 +5559,7 @@ class CLIManager:
                 print_error(
                     "Invalid destination hotkey ss58 address. Please enter a valid ss58 address or wallet name."
                 )
-                raise typer.Exit()
+                raise typer.Exit(1)
 
         if not wallet_name:
             wallet_name = Prompt.ask(
@@ -6347,7 +6347,7 @@ class CLIManager:
 
         if all_netuids and netuid:
             print_error("Specify either a netuid or `--all`, not both.")
-            raise typer.Exit()
+            raise typer.Exit(1)
 
         if all_netuids:
             netuid = None
@@ -6422,11 +6422,11 @@ class CLIManager:
 
         if len(proportions) != len(children):
             print_error("You must have as many proportions as you have children.")
-            raise typer.Exit()
+            raise typer.Exit(1)
 
         if sum(proportions) > 1.0:
             print_error("Your proportion total must not exceed 1.0.")
-            raise typer.Exit()
+            raise typer.Exit(1)
 
         wallet = self.wallet_ask(
             wallet_name,
@@ -6506,7 +6506,7 @@ class CLIManager:
         )
         if all_netuids and netuid:
             print_error("Specify either a netuid or '--all', not both.")
-            raise typer.Exit()
+            raise typer.Exit(1)
         if all_netuids:
             netuid = None
         elif not netuid:
@@ -6601,7 +6601,7 @@ class CLIManager:
         )
         if all_netuids and netuid:
             print_error("Specify either a netuid or '--all', not both.")
-            raise typer.Exit()
+            raise typer.Exit(1)
         if all_netuids:
             netuid = None
         elif not netuid:
@@ -7360,7 +7360,7 @@ class CLIManager:
             print_error(
                 f"Take value must be between {min_value} and {max_value}. Provided value: {take}"
             )
-            raise typer.Exit()
+            raise typer.Exit(1)
         logger.debug(f"args:\nnetwork: {network}\ntake: {take}\nproxy: {proxy}\n")
         result, ext_id = self._run_command(
             sudo.set_take(
@@ -7542,11 +7542,11 @@ class CLIManager:
 
         if amount <= 0:
             print_error(f"You entered an incorrect stake and burn amount: {amount}")
-            raise typer.Exit()
+            raise typer.Exit(1)
 
         if netuid == 0:
             print_error("Cannot stake and burn on the root subnet.")
-            raise typer.Exit()
+            raise typer.Exit(1)
 
         self._run_command(
             sudo.stake_burn(
@@ -8266,18 +8266,18 @@ class CLIManager:
                 "Unable to use `--reuse-last` or `--html` when config `no-cache` is set to `True`. "
                 "Set the`no-cache` field to `False` by using `btcli config set` or editing the config.yml file."
             )
-            raise typer.Exit()
+            raise typer.Exit(1)
 
         # For Rao games
         effective_network = get_effective_network(self.config, network)
         if is_rao_network(effective_network):
             print_error("This command is disabled on the 'rao' network.")
-            raise typer.Exit()
+            raise typer.Exit(1)
 
         if reuse_last:
             if netuid is not None:
                 console.print("Cannot specify netuid when using `--reuse-last`")
-                raise typer.Exit()
+                raise typer.Exit(1)
             subtensor = None
         else:
             if netuid is None:
@@ -8604,7 +8604,7 @@ class CLIManager:
         if coldkey_ss58:
             if not is_valid_ss58_address(coldkey_ss58):
                 print_error(f"Invalid SS58 address: {coldkey_ss58}")
-                raise typer.Exit()
+                raise typer.Exit(1)
             wallet = None
         else:
             wallet = self.wallet_ask(
@@ -10219,7 +10219,7 @@ class CLIManager:
         """
         if from_tao is None and from_rao is None:
             print_error("Specify `--rao` and/or `--tao`.")
-            raise typer.Exit()
+            raise typer.Exit(1)
         if from_rao is not None:
             rao = int(float(from_rao))
             console.print(

--- a/tests/unit_tests/test_cli_exit_codes.py
+++ b/tests/unit_tests/test_cli_exit_codes.py
@@ -1,0 +1,31 @@
+"""Regression tests pinning CLI error paths to a non-zero exit code.
+
+Several validation sites previously called ``raise typer.Exit()`` (default
+exit code 0) after ``print_error(...)``, so error conditions reported success
+to the shell. These tests pin the corrected behavior at representative sites.
+"""
+
+import pytest
+import typer
+
+from bittensor_cli.cli import parse_mnemonic
+
+
+class TestParseMnemonicExitCode:
+    def test_numbered_mnemonic_not_starting_at_1_exits_nonzero(self):
+        # cli.py:588 — "Numbered mnemonics must begin with 1"
+        with pytest.raises(typer.Exit) as exc_info:
+            parse_mnemonic("2-hello 3-how 4-are 5-you")
+        assert exc_info.value.exit_code == 1
+
+    def test_numbered_mnemonic_with_missing_numbers_exits_nonzero(self):
+        # cli.py:596 — "Missing or duplicate numbers in a numbered mnemonic"
+        with pytest.raises(typer.Exit) as exc_info:
+            parse_mnemonic("1-hello 3-are 4-you")
+        assert exc_info.value.exit_code == 1
+
+    def test_numbered_mnemonic_with_duplicate_numbers_exits_nonzero(self):
+        # cli.py:596 — duplicate numbers branch
+        with pytest.raises(typer.Exit) as exc_info:
+            parse_mnemonic("1-hello 1-how 2-are 3-you")
+        assert exc_info.value.exit_code == 1


### PR DESCRIPTION
## Summary
- 36 sites in `bittensor_cli/cli.py` printed an error via `print_error(...)` and then called `raise typer.Exit()` without an argument. `typer.Exit()` defaults to exit code **0**, so the shell saw `$? = 0` on real validation / lookup failures.
- Two existing sites already use the correct `raise typer.Exit(1)` (lines 2572 and 4289), so the fix matches the in-repo pattern.

## Reproducer
```
$ btcli wallet transfer --destination invalidss58 --amount 1; echo $?
Error: You have entered an incorrect ss58 address. Please try again.
0    # <- previously: success exit code on a validation failure
```

After this PR: same command exits `1`, so wrapper scripts and CI pipelines can now detect btcli failures.

## Sites changed (36)
Validation / lookup / mutually-exclusive-flag errors:
- Mnemonic parsing (588, 596)
- File existence (642, 750)
- Mutually-exclusive flags: `--quiet/--verbose` (1641), `--include/--exclude-hotkeys` (2674), `netuid/--all` (6350, 6509, 6604), `--reuse-last`/cache (8269, 8280)
- SS58 / address validation (2784, 4069, 4571, 4721, 5554, 5562, 8607)
- Wallet / hotkey / subnet not found (2549, 2556, 2442, 2450)
- Numeric range / amount checks (5035, 5040, 7363, 7545, 7549)
- Children / proportions validation (6425, 6429)
- Endpoint validation (1840), proxy duplicate (2031), disabled-command paths (3900, 8275)
- Empty SS58 set after filter (3818, 3841)
- Missing required input (10222)

## Sites intentionally preserved (10)
These are graceful exits, not errors — keeping `typer.Exit()` (code 0):
- `--version` and `--commands` flag display (723, 733)
- Mixed success+failure cleanup paths (772, 1523, 6946)
- User-declined `confirm_action(...)` prompts (1829, 1837, 5536, 5748)
- Explicit user-abort message (4006)

## Tests
Adds `tests/unit_tests/test_cli_exit_codes.py` pinning the corrected exit code via `parse_mnemonic` for lines 588 and 596:
- `parse_mnemonic("2-hello 3-how ...")` → exit code 1 (numbered mnemonic must begin with 1)
- `parse_mnemonic("1-hello 3-are 4-you")` → exit code 1 (missing numbers)
- `parse_mnemonic("1-hello 1-how 2-are 3-you")` → exit code 1 (duplicate numbers)