### PR TITLE
Release/9.21.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 * Bumps Cyscale and ASI by @thewhaleking
   in https://github.com/latent-to/btcli/commit/ff711fd84a75f0d6dba8206ebf4391cbf06058e5
+* fix(cli): exit non-zero on validation and lookup errors by @dhgoal
+  in https://github.com/latent-to/btcli/pull/947
 
 **Full Changelog**: https://github.com/latent-to/btcli/compare/v9.21.0...v9.21.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 9.21.1 /2026-04-29
+
+## What's Changed
+
+* Bumps Cyscale and ASI by @thewhaleking
+  in https://github.com/latent-to/btcli/commit/ff711fd84a75f0d6dba8206ebf4391cbf06058e5
+
+**Full Changelog**: https://github.com/latent-to/btcli/compare/v9.21.0...v9.21.1
+
 ## 9.21.0 /2026-04-28
 
 ## What's Changed

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -1588,6 +1588,7 @@ class CLIManager:
                 f.write(
                     f"BTCLI {__version__}\n"
                     f"Async-Substrate-Interface: {importlib.metadata.version('async-substrate-interface')}\n"
+                    f"Cyscale: {importlib.metadata.version('cyscale')}\n"
                     f"Bittensor-Wallet: {importlib.metadata.version('bittensor-wallet')}\n"
                     f"Command: {' '.join(sys.argv)}\n"
                     f"Config: {self.config}\n"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "wheel",
-    "async-substrate-interface==2.0.2",
+    "async-substrate-interface>=2.0.3,<3.0.0",
     "aiohttp~=3.13",
     "backoff~=2.2.1",
     "bittensor-drand>=1.3.0",
@@ -40,7 +40,7 @@ dependencies = [
     "pycryptodome>=3.0.0,<4.0.0",
     "PyYAML~=6.0",
     "rich>=13.7,<15.0",
-    "cyscale>=0.3.1,<1.0.0",
+    "cyscale>=0.3.3,<1.0.0",
     "typer>=0.16",
     "typing_extensions>4.0.0; python_version<'3.11'",
     "bittensor-wallet==4.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "bittensor-cli"
-version = "9.21.0"
+version = "9.21.1"
 description = "Bittensor CLI"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## 9.21.1 /2026-04-29

## What's Changed

* Bumps Cyscale and ASI by @thewhaleking
  in https://github.com/latent-to/btcli/commit/ff711fd84a75f0d6dba8206ebf4391cbf06058e5
* fix(cli): exit non-zero on validation and lookup errors by @dhgoal
  in https://github.com/latent-to/btcli/pull/947

**Full Changelog**: https://github.com/latent-to/btcli/compare/v9.21.0...v9.21.1
