### PR TITLE
Bumps wheel for CVE-2026-24049

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ classifiers = [
     "Topic :: Utilities"
 ]
 dependencies = [
-    "wheel",
+    "wheel>0.46.1",
     "async-substrate-interface>=2.0.3,<3.0.0",
     "aiohttp~=3.13",
     "backoff~=2.2.1",


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2026-24049

Was just `wheel` before, so risk was already extremely low. This is just CYA.