### PR TITLE
Fixes test import

### DIFF
--- a/tests/unit_tests/test_sudo_stake_burn.py
+++ b/tests/unit_tests/test_sudo_stake_burn.py
@@ -6,7 +6,7 @@ import pytest
 from bittensor_cli.src.bittensor.balances import Balance
 from bittensor_cli.src.commands.sudo import stake_burn
 
-from tests.unit_tests.conftest import COLDKEY_SS58 as TEST_SS58, HOTKEY_SS58
+from .conftest import COLDKEY_SS58 as TEST_SS58, HOTKEY_SS58
 
 
 class MockSubnetInfo:


### PR DESCRIPTION
Keeps it consistent with the rest of tests. 

There's a weird issue with python namespaces when running the unit tests from another directory (see the test failure at https://github.com/latent-to/async-substrate-interface/actions/runs/25796669094/job/75775652969?pr=349)