### PR TITLE
Fix nonce assignment in mev protection

### DIFF
--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -1181,13 +1181,11 @@ class SubtensorInterface:
             max_mev_era = 8
             if era is None or era["period"] > max_mev_era:
                 era = {"period": max_mev_era}
-            next_nonce = await self.substrate.get_account_next_index(
-                keypair.ss58_address
-            )
-            inner_extrinsic = await create_signed(call, next_nonce)
+            shield_nonce = call_args["nonce"]
+            inner_extrinsic = await create_signed(call, shield_nonce + 1)
             inner_hash = f"0x{inner_extrinsic.extrinsic_hash.hex()}"
             shield_call = await encrypt_extrinsic(self, inner_extrinsic)
-            extrinsic = await create_signed(shield_call, nonce)
+            extrinsic = await create_signed(shield_call, shield_nonce)
         else:
             extrinsic = await self.substrate.create_signed_extrinsic(**call_args)
         try:

--- a/tests/e2e_tests/test_staking_sudo.py
+++ b/tests/e2e_tests/test_staking_sudo.py
@@ -487,8 +487,8 @@ def test_staking(local_chain, wallet_setup):
                 wallet_alice.hotkey.ss58_address
             ]
 
-        assert line("staking_success") is True
         assert line("error_messages") == ""
+        assert line("staking_success") is True
         assert isinstance(line("extrinsic_ids"), str)
 
     # Fetch the hyperparameters of the subnet


### PR DESCRIPTION
Nonce assignment was previously bumping the nonce cache, but because of how the nonce is handled in a `None` instance, it was reverting, resulting in a future response, because there was never the preceding nonce sent.