### PR TITLE
Clears the nonce cache on extrinsic submission failure

### DIFF
--- a/bittensor_cli/src/bittensor/subtensor_interface.py
+++ b/bittensor_cli/src/bittensor/subtensor_interface.py
@@ -1222,6 +1222,9 @@ class SubtensorInterface:
             else:
                 return False, format_error_message(await response.error_message), None
         except SubstrateRequestException as e:
+            # The extrinsic was rejected before inclusion, so the nonce was not consumed
+            # on-chain. Clear the cached next-index so subsequent calls refetch the truth.
+            self.substrate.clear_nonce_cache_for_account(keypair.ss58_address)
             err_msg = format_error_message(e)
             if mev_protection and "'result': 'invalid'" in str(e).lower():
                 err_msg = (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 ]
 dependencies = [
     "wheel>0.46.1",
-    "async-substrate-interface>=2.0.3,<3.0.0",
+    "async-substrate-interface>=2.0.4,<3.0.0",
     "aiohttp~=3.13",
     "bittensor-drand>=1.3.0",
     "GitPython>=3.0.0",


### PR DESCRIPTION
Safer for edge-cases