### PR TITLE
Adds support for new crypto type param of bt-wallet

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -66,6 +66,8 @@ from bittensor_cli.src.bittensor.utils import (
     get_effective_network,
     prompt_for_identity,
     validate_uri,
+    CryptoType,
+    crypto_type_to_int,
     prompt_for_subnet_identity,
     validate_rate_tolerance,
     get_hotkey_pub_ss58,
@@ -375,6 +377,11 @@ class Options:
         "--uri",
         help="Create wallet from uri (e.g. 'Alice', 'Bob', 'Charlie', 'Dave', 'Eve')",
         callback=validate_uri,
+    )
+    crypto_type = typer.Option(
+        CryptoType.SR25519.value,
+        "--crypto-type",
+        help="Cryptographic scheme for the new key.",
     )
     rate_tolerance = typer.Option(
         None,
@@ -1071,6 +1078,12 @@ class CLIManager:
         self.wallet_app.command(
             "verify", rich_help_panel=HELP_PANELS["WALLET"]["OPERATIONS"]
         )(self.wallet_verify)
+        self.wallet_app.command(
+            "encrypt", rich_help_panel=HELP_PANELS["WALLET"]["OPERATIONS"]
+        )(self.wallet_encrypt)
+        self.wallet_app.command(
+            "decrypt", rich_help_panel=HELP_PANELS["WALLET"]["OPERATIONS"]
+        )(self.wallet_decrypt)
 
         # axon commands
         self.axon_app.command("reset")(self.axon_reset)
@@ -3047,6 +3060,7 @@ class CLIManager:
         json_password: Optional[str] = Options.json_password,
         use_password: Optional[bool] = Options.use_password,
         overwrite: bool = Options.overwrite,
+        crypto_type: CryptoType = Options.crypto_type,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
         json_output: bool = Options.json_output,
@@ -3098,6 +3112,7 @@ class CLIManager:
                 use_password,
                 overwrite,
                 json_output,
+                crypto_type=crypto_type_to_int(crypto_type),
             )
         )
 
@@ -3109,6 +3124,7 @@ class CLIManager:
         public_key_hex: Optional[str] = Options.public_hex_key,
         ss58_address: Optional[str] = Options.ss58_address,
         overwrite: bool = Options.overwrite,
+        crypto_type: CryptoType = Options.crypto_type,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
         json_output: bool = Options.json_output,
@@ -3160,7 +3176,12 @@ class CLIManager:
         # do not logger.debug any creation cmds
         return self._run_command(
             wallets.regen_coldkey_pub(
-                wallet, ss58_address, public_key_hex, overwrite, json_output
+                wallet,
+                ss58_address,
+                public_key_hex,
+                overwrite,
+                json_output,
+                crypto_type=crypto_type_to_int(crypto_type),
             )
         )
 
@@ -3178,6 +3199,7 @@ class CLIManager:
             help="Set to 'True' to protect the generated Bittensor key with a password.",
         ),
         overwrite: bool = Options.overwrite,
+        crypto_type: CryptoType = Options.crypto_type,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
         json_output: bool = Options.json_output,
@@ -3221,6 +3243,7 @@ class CLIManager:
                 use_password,
                 overwrite,
                 json_output,
+                crypto_type=crypto_type_to_int(crypto_type),
             )
         )
 
@@ -3232,6 +3255,7 @@ class CLIManager:
         public_key_hex: Optional[str] = Options.public_hex_key,
         ss58_address: Optional[str] = Options.ss58_address,
         overwrite: bool = Options.overwrite,
+        crypto_type: CryptoType = Options.crypto_type,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
         json_output: bool = Options.json_output,
@@ -3283,7 +3307,12 @@ class CLIManager:
         # do not logger.debug any creation cmds
         return self._run_command(
             wallets.regen_hotkey_pub(
-                wallet, ss58_address, public_key_hex, overwrite, json_output
+                wallet,
+                ss58_address,
+                public_key_hex,
+                overwrite,
+                json_output,
+                crypto_type=crypto_type_to_int(crypto_type),
             )
         )
 
@@ -3304,6 +3333,7 @@ class CLIManager:
         ),
         uri: Optional[str] = Options.uri,
         overwrite: bool = Options.overwrite,
+        crypto_type: CryptoType = Options.crypto_type,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
         json_output: bool = Options.json_output,
@@ -3348,7 +3378,13 @@ class CLIManager:
         # do not logger.debug any creation cmds
         return self._run_command(
             wallets.new_hotkey(
-                wallet, n_words, use_password, uri, overwrite, json_output
+                wallet,
+                n_words,
+                use_password,
+                uri,
+                overwrite,
+                json_output,
+                crypto_type=crypto_type_to_int(crypto_type),
             )
         )
 
@@ -3446,6 +3482,7 @@ class CLIManager:
         use_password: Optional[bool] = Options.use_password,
         uri: Optional[str] = Options.uri,
         overwrite: bool = Options.overwrite,
+        crypto_type: CryptoType = Options.crypto_type,
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
         json_output: bool = Options.json_output,
@@ -3488,7 +3525,13 @@ class CLIManager:
             n_words = get_n_words(n_words)
         return self._run_command(
             wallets.new_coldkey(
-                wallet, n_words, use_password, uri, overwrite, json_output
+                wallet,
+                n_words,
+                use_password,
+                uri,
+                overwrite,
+                json_output,
+                crypto_type=crypto_type_to_int(crypto_type),
             )
         )
 
@@ -3584,6 +3627,16 @@ class CLIManager:
         use_password: bool = Options.use_password,
         uri: Optional[str] = Options.uri,
         overwrite: bool = Options.overwrite,
+        coldkey_crypto_type: CryptoType = typer.Option(
+            CryptoType.SR25519.value,
+            "--coldkey-crypto-type",
+            help="Cryptographic scheme for the new coldkey.",
+        ),
+        hotkey_crypto_type: CryptoType = typer.Option(
+            CryptoType.SR25519.value,
+            "--hotkey-crypto-type",
+            help="Cryptographic scheme for the new hotkey.",
+        ),
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
         json_output: bool = Options.json_output,
@@ -3630,7 +3683,14 @@ class CLIManager:
         # do not logger.debug any creation commands
         return self._run_command(
             wallets.wallet_create(
-                wallet, n_words, use_password, uri, overwrite, json_output
+                wallet,
+                n_words,
+                use_password,
+                uri,
+                overwrite,
+                json_output,
+                coldkey_crypto_type=crypto_type_to_int(coldkey_crypto_type),
+                hotkey_crypto_type=crypto_type_to_int(hotkey_crypto_type),
             )
         )
 
@@ -4088,6 +4148,93 @@ class CLIManager:
 
         return self._run_command(
             wallets.verify(message, signature, public_key_or_ss58, json_output)
+        )
+
+    def wallet_encrypt(
+        self,
+        to_ss58: Optional[str] = typer.Option(
+            None,
+            "--to",
+            "--to-ss58",
+            "-t",
+            help="SS58 address of the recipient (must be an ED25519 address).",
+        ),
+        message: str = typer.Option("", "--message", "-m", help="Message to encrypt."),
+        quiet: bool = Options.quiet,
+        verbose: bool = Options.verbose,
+        json_output: bool = Options.json_output,
+    ):
+        """
+        Encrypt a message to a recipient ED25519 SS58 address.
+
+        Encryption is ED25519-only. The ciphertext is printed as hex; the recipient
+        can decrypt it with `btcli wallet decrypt` using their ED25519 wallet.
+
+        EXAMPLE
+
+        [green]$[/green] btcli wallet encrypt --to 5FA9nQDVg267DEd8m1ZypXLBnvN7SFxYwV7ndqSYGiN9TTpu --message "hello"
+        """
+        self.verbosity_handler(quiet, verbose, json_output, False)
+        if not to_ss58:
+            to_ss58 = Prompt.ask("Enter the recipient [blue]SS58 address[/blue]")
+        if not message:
+            message = Prompt.ask("Enter the [blue]message[/blue] to encrypt")
+        return self._run_command(wallets.encrypt_message(to_ss58, message, json_output))
+
+    def wallet_decrypt(
+        self,
+        wallet_path: str = Options.wallet_path,
+        wallet_name: str = Options.wallet_name,
+        wallet_hotkey: str = Options.wallet_hotkey,
+        use_hotkey: Optional[bool] = typer.Option(
+            None,
+            "--use-hotkey/--no-use-hotkey",
+            help="If specified, decrypt with the hotkey. If not specified, the user will be prompted.",
+        ),
+        ciphertext: str = typer.Option(
+            "",
+            "--ciphertext",
+            "-c",
+            help="Hex-encoded ciphertext produced by `btcli wallet encrypt`.",
+        ),
+        quiet: bool = Options.quiet,
+        verbose: bool = Options.verbose,
+        decline: bool = Options.decline,
+        json_output: bool = Options.json_output,
+    ):
+        """
+        Decrypt a hex-encoded ciphertext using an ED25519 wallet key.
+
+        EXAMPLE
+
+        [green]$[/green] btcli wallet decrypt --wallet-name default --ciphertext 0x51...
+
+        [bold]Note[/bold]: the coldkey or hotkey used must be ED25519 (create one with
+        `btcli wallet new-coldkey --crypto-type ed25519`).
+        """
+        self.verbosity_handler(quiet, verbose, json_output, False, decline)
+        if use_hotkey is None:
+            use_hotkey = confirm_action(
+                f"Would you like to decrypt with your [{COLORS.G.HK}]hotkey[/{COLORS.G.HK}]?"
+                f"\n[Type [{COLORS.G.HK}]y[/{COLORS.G.HK}] for [{COLORS.G.HK}]hotkey[/{COLORS.G.HK}]"
+                f" and [{COLORS.G.CK}]n[/{COLORS.G.CK}] for [{COLORS.G.CK}]coldkey[/{COLORS.G.CK}]] "
+                f"(default is [{COLORS.G.CK}]coldkey[/{COLORS.G.CK}])",
+                default=False,
+                decline=decline,
+                quiet=quiet,
+            )
+
+        ask_for = [WO.HOTKEY, WO.PATH, WO.NAME] if use_hotkey else [WO.NAME, WO.PATH]
+        validate = WV.WALLET_AND_HOTKEY if use_hotkey else WV.WALLET
+
+        wallet = self.wallet_ask(
+            wallet_name, wallet_path, wallet_hotkey, ask_for=ask_for, validate=validate
+        )
+        if not ciphertext:
+            ciphertext = Prompt.ask("Enter the [blue]ciphertext[/blue] (hex)")
+
+        return self._run_command(
+            wallets.decrypt_message(wallet, ciphertext, use_hotkey, json_output)
         )
 
     def wallet_swap_coldkey(

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -4113,6 +4113,14 @@ class CLIManager:
             "-p",
             help="SS58 address or public key (hex) of the signer",
         ),
+        crypto_type: Optional[CryptoType] = typer.Option(
+            None,
+            "--crypto-type",
+            help=(
+                "Cryptographic scheme used to produce the signature. "
+                "If omitted, both sr25519 and ed25519 are tried."
+            ),
+        ),
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
         json_output: bool = Options.json_output,
@@ -4125,13 +4133,15 @@ class CLIManager:
         USAGE
 
         Provide the original message, the signature (in hex format), and either the SS58 address
-        or public key of the signer to verify the signature.
+        or public key of the signer to verify the signature. If you know which cryptographic scheme
+        was used, pass --crypto-type; otherwise both sr25519 and ed25519 are tried automatically and
+        the matching scheme is reported.
 
         EXAMPLES
 
         [green]$[/green] btcli wallet verify --message "Hello world" --signature "0xabc123..." --address "5GrwvaEF..."
 
-        [green]$[/green] btcli wallet verify -m "Test message" -s "0xdef456..." -p "0x1234abcd..."
+        [green]$[/green] btcli wallet verify -m "Test message" -s "0xdef456..." -p "0x1234abcd..." --crypto-type ed25519
         """
         self.verbosity_handler(quiet, verbose, json_output, False)
 
@@ -4147,7 +4157,9 @@ class CLIManager:
             signature = Prompt.ask("Enter the [blue]signature[/blue]")
 
         return self._run_command(
-            wallets.verify(message, signature, public_key_or_ss58, json_output)
+            wallets.verify(
+                message, signature, public_key_or_ss58, crypto_type, json_output
+            )
         )
 
     def wallet_encrypt(

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -16,7 +16,7 @@ import re
 
 import aiohttp
 from async_substrate_interface import AsyncExtrinsicReceipt
-from bittensor_wallet import Wallet, Keypair
+from bittensor_wallet import Wallet, Keypair, CRYPTO_ED25519, CRYPTO_SR25519
 from bittensor_wallet.utils import SS58_FORMAT
 from bittensor_wallet.errors import KeyFileError, PasswordError
 from bittensor_wallet import utils
@@ -1567,7 +1567,6 @@ class CryptoType(StrEnum):
 
 def crypto_type_to_int(value: CryptoType) -> int:
     """Map a CryptoType enum to the bittensor_wallet crypto_type int constant."""
-    from bittensor_wallet import CRYPTO_ED25519, CRYPTO_SR25519
 
     return {
         CryptoType.SR25519: CRYPTO_SR25519,

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -1574,6 +1574,34 @@ def crypto_type_to_int(value: CryptoType) -> int:
     }[value]
 
 
+def crypto_type_from_int(value: int) -> Optional[CryptoType]:
+    """Map a bittensor_wallet crypto_type int constant back to a CryptoType enum.
+
+    Returns ``None`` for unrecognized values so callers can fall back gracefully.
+    """
+
+    return {
+        CRYPTO_SR25519: CryptoType.SR25519,
+        CRYPTO_ED25519: CryptoType.ED25519,
+    }.get(value)
+
+
+def crypto_type_tag(value: int) -> str:
+    """Render a small rich-markup tag showing the crypto scheme of a keypair.
+
+    SR25519 (the default) uses a muted cyan tag and ED25519 a bold magenta one
+    so the non-default scheme is easy to spot when scanning a list.
+    """
+
+    ct = crypto_type_from_int(value)
+    # Brackets must be escaped (\\[) so rich does not parse them as markup.
+    if ct is CryptoType.SR25519:
+        return r"[dim cyan]\[sr25519][/dim cyan]"
+    if ct is CryptoType.ED25519:
+        return r"[bold magenta]\[ed25519][/bold magenta]"
+    return r"[dim]\[?][/dim]"
+
+
 def get_effective_network(config, network: Optional[list[str]]) -> str:
     """
     Determines the effective network to be used, considering the network parameter,

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -1550,6 +1550,31 @@ def validate_uri(uri: str) -> str:
     return f"//{clean_uri.capitalize()}"
 
 
+# TODO when 3.10 support is dropped in Oct 2026, switch to enum.StrEnum directly
+if sys.version_info >= (3, 11):
+    from enum import StrEnum
+else:
+    from enum import Enum
+
+    class StrEnum(str, Enum):
+        pass
+
+
+class CryptoType(StrEnum):
+    SR25519 = "sr25519"
+    ED25519 = "ed25519"
+
+
+def crypto_type_to_int(value: CryptoType) -> int:
+    """Map a CryptoType enum to the bittensor_wallet crypto_type int constant."""
+    from bittensor_wallet import CRYPTO_ED25519, CRYPTO_SR25519
+
+    return {
+        CryptoType.SR25519: CRYPTO_SR25519,
+        CryptoType.ED25519: CRYPTO_ED25519,
+    }[value]
+
+
 def get_effective_network(config, network: Optional[list[str]]) -> str:
     """
     Determines the effective network to be used, considering the network parameter,

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -7,7 +7,7 @@ from enum import Enum
 from typing import Generator, Optional, Union
 
 import aiohttp
-from bittensor_wallet import Wallet, Keypair
+from bittensor_wallet import CRYPTO_ED25519, CRYPTO_SR25519, Wallet, Keypair
 from bittensor_wallet.errors import KeyFileError
 from bittensor_wallet.keyfile import Keyfile
 from rich import box
@@ -156,6 +156,7 @@ async def regen_coldkey(
     use_password: Optional[bool] = True,
     overwrite: Optional[bool] = False,
     json_output: bool = False,
+    crypto_type: int = CRYPTO_SR25519,
 ):
     """Creates a new coldkey under this wallet"""
     json_str: Optional[str] = None
@@ -173,6 +174,7 @@ async def regen_coldkey(
             json=(json_str, json_password) if all([json_str, json_password]) else None,
             use_password=use_password,
             overwrite=overwrite,
+            crypto_type=crypto_type,
         )
         if isinstance(new_wallet, Wallet):
             console.print(
@@ -217,6 +219,7 @@ async def regen_coldkey_pub(
     public_key_hex: str,
     overwrite: Optional[bool] = False,
     json_output: bool = False,
+    crypto_type: int = CRYPTO_SR25519,
 ):
     """Creates a new coldkeypub under this wallet."""
     try:
@@ -224,6 +227,7 @@ async def regen_coldkey_pub(
             ss58_address=ss58_address,
             public_key=public_key_hex,
             overwrite=overwrite,
+            crypto_type=crypto_type,
         )
         if isinstance(new_coldkeypub, Wallet):
             console.print(
@@ -264,6 +268,7 @@ async def regen_hotkey(
     use_password: Optional[bool] = False,
     overwrite: Optional[bool] = False,
     json_output: bool = False,
+    crypto_type: int = CRYPTO_SR25519,
 ):
     """Creates a new hotkey under this wallet."""
     json_str: Optional[str] = None
@@ -282,6 +287,7 @@ async def regen_hotkey(
             json=(json_str, json_password) if all([json_str, json_password]) else None,
             use_password=use_password,
             overwrite=overwrite,
+            crypto_type=crypto_type,
         )
         if isinstance(new_hotkey_, Wallet):
             console.print(
@@ -325,6 +331,7 @@ async def regen_hotkey_pub(
     public_key_hex: str,
     overwrite: Optional[bool] = False,
     json_output: bool = False,
+    crypto_type: int = CRYPTO_SR25519,
 ):
     """Creates a new hotkeypub under this wallet."""
     try:
@@ -332,6 +339,7 @@ async def regen_hotkey_pub(
             ss58_address=ss58_address,
             public_key=public_key_hex,
             overwrite=overwrite,
+            crypto_type=crypto_type,
         )
         if isinstance(new_hotkeypub, Wallet):
             console.print(
@@ -370,12 +378,13 @@ async def new_hotkey(
     uri: Optional[str] = None,
     overwrite: Optional[bool] = False,
     json_output: bool = False,
+    crypto_type: int = CRYPTO_SR25519,
 ):
     """Creates a new hotkey under this wallet."""
     try:
         if uri:
             try:
-                keypair = Keypair.create_from_uri(uri)
+                keypair = Keypair.create_from_uri(uri, crypto_type=crypto_type)
             except TypeError as e:
                 print_error(f"Failed to create keypair from URI {uri}: {str(e)}")
                 return
@@ -388,6 +397,7 @@ async def new_hotkey(
                 n_words=n_words,
                 use_password=use_password,
                 overwrite=overwrite,
+                crypto_type=crypto_type,
             )
             console.print("[dark_sea_green]Hotkey created[/dark_sea_green]")
         if json_output:
@@ -421,12 +431,13 @@ async def new_coldkey(
     uri: Optional[str] = None,
     overwrite: Optional[bool] = False,
     json_output: bool = False,
+    crypto_type: int = CRYPTO_SR25519,
 ):
     """Creates a new coldkey under this wallet."""
     try:
         if uri:
             try:
-                keypair = Keypair.create_from_uri(uri)
+                keypair = Keypair.create_from_uri(uri, crypto_type=crypto_type)
             except TypeError as e:
                 print_error(f"Failed to create keypair from URI {uri}: {str(e)}")
                 if json_output:
@@ -450,6 +461,7 @@ async def new_coldkey(
                 n_words=n_words,
                 use_password=use_password,
                 overwrite=overwrite,
+                crypto_type=crypto_type,
             )
             console.print("[dark_sea_green]Coldkey created[/dark_sea_green]")
         if json_output:
@@ -487,6 +499,8 @@ async def wallet_create(
     uri: Optional[str] = None,
     overwrite: Optional[bool] = False,
     json_output: bool = False,
+    coldkey_crypto_type: int = CRYPTO_SR25519,
+    hotkey_crypto_type: int = CRYPTO_SR25519,
 ):
     """Creates a new wallet."""
     output_dict: dict[str, Optional[Union[bool, str, dict]]] = {
@@ -497,7 +511,8 @@ async def wallet_create(
 
     if uri:
         try:
-            keypair = Keypair.create_from_uri(uri)
+            # URI creates a single keypair shared by cold/hot; only one crypto_type can apply.
+            keypair = Keypair.create_from_uri(uri, crypto_type=coldkey_crypto_type)
             wallet.set_coldkey(keypair=keypair, encrypt=False, overwrite=overwrite)
             wallet.set_coldkeypub(keypair=keypair, encrypt=False, overwrite=overwrite)
             wallet.set_hotkey(keypair=keypair, encrypt=False, overwrite=overwrite)
@@ -523,6 +538,7 @@ async def wallet_create(
                 n_words=n_words,
                 use_password=use_password,
                 overwrite=overwrite,
+                crypto_type=coldkey_crypto_type,
             )
             console.print("[dark_sea_green]Coldkey created[/dark_sea_green]")
         except KeyFileError as error:
@@ -537,6 +553,7 @@ async def wallet_create(
                 n_words=n_words,
                 use_password=False,
                 overwrite=overwrite,
+                crypto_type=hotkey_crypto_type,
             )
             console.print("[dark_sea_green]Hotkey created[/dark_sea_green]")
             output_dict["success"] = True
@@ -2090,6 +2107,126 @@ async def verify(
             print_error("Signature verification failed!")
 
     return is_valid
+
+
+async def encrypt_message(
+    recipient_ss58: str,
+    message: str,
+    json_output: bool = False,
+):
+    """Encrypt a message to a recipient SS58 address (ED25519 only)."""
+    if not is_valid_ss58_address(recipient_ss58):
+        err = f"Invalid recipient SS58 address: {recipient_ss58}"
+        if json_output:
+            json_console.print(json.dumps({"success": False, "error": err}))
+        else:
+            print_error(err)
+        return False
+
+    try:
+        ciphertext = Keypair.encrypt_for(
+            recipient_ss58, message.encode("utf-8"), CRYPTO_ED25519
+        )
+    except Exception as e:
+        err = f"Encryption failed: {e}"
+        if json_output:
+            json_console.print(json.dumps({"success": False, "error": err}))
+        else:
+            print_error(err)
+        return False
+
+    ciphertext_hex = ciphertext.hex()
+    if json_output:
+        json_console.print(
+            json.dumps(
+                {
+                    "success": True,
+                    "data": {
+                        "recipient": recipient_ss58,
+                        "ciphertext_hex": ciphertext_hex,
+                    },
+                }
+            )
+        )
+    else:
+        console.print("[dark_sea_green3]Message encrypted successfully!\n")
+        console.print(f"[yellow]Recipient:[/yellow] {recipient_ss58}")
+        console.print(f"[yellow]Ciphertext (hex):[/yellow]\n{ciphertext_hex}")
+    return True
+
+
+async def decrypt_message(
+    wallet: Wallet,
+    ciphertext_hex: str,
+    use_hotkey: bool,
+    json_output: bool = False,
+):
+    """Decrypt a hex-encoded ciphertext with the wallet's ED25519 keypair."""
+    try:
+        ciphertext = bytes.fromhex(
+            ciphertext_hex.strip().lower().removeprefix("0x")
+        )
+    except ValueError as e:
+        err = f"Invalid ciphertext hex: {e}"
+        if json_output:
+            json_console.print(json.dumps({"success": False, "error": err}))
+        else:
+            print_error(err)
+        return False
+
+    if not unlock_key(wallet, "hot" if use_hotkey else "cold").success:
+        return False
+
+    keypair = wallet.hotkey if use_hotkey else wallet.coldkey
+    if keypair.crypto_type != CRYPTO_ED25519:
+        err = (
+            "Decryption requires an ED25519 keypair. "
+            f"This {'hotkey' if use_hotkey else 'coldkey'} uses a different scheme."
+        )
+        if json_output:
+            json_console.print(json.dumps({"success": False, "error": err}))
+        else:
+            print_error(err)
+        return False
+
+    try:
+        plaintext = keypair.decrypt(ciphertext)
+    except Exception as e:
+        err = f"Decryption failed: {e}"
+        if json_output:
+            json_console.print(json.dumps({"success": False, "error": err}))
+        else:
+            print_error(err)
+        return False
+
+    try:
+        plaintext_str = plaintext.decode("utf-8")
+    except UnicodeDecodeError:
+        plaintext_str = None
+
+    if json_output:
+        json_console.print(
+            json.dumps(
+                {
+                    "success": True,
+                    "data": {
+                        "recipient": keypair.ss58_address,
+                        "plaintext": plaintext_str,
+                        "plaintext_hex": plaintext.hex(),
+                    },
+                }
+            )
+        )
+    else:
+        console.print("[dark_sea_green3]Message decrypted successfully!\n")
+        console.print(f"[yellow]Recipient:[/yellow] {keypair.ss58_address}")
+        if plaintext_str is not None:
+            console.print(f"[yellow]Plaintext:[/yellow]\n{plaintext_str}")
+        else:
+            console.print(
+                f"[yellow]Plaintext (non-UTF8, hex):[/yellow]\n{plaintext.hex()}"
+            )
+    return True
 
 
 def compute_coldkey_hash(ss58_address: str) -> str:

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -2163,9 +2163,7 @@ async def decrypt_message(
 ):
     """Decrypt a hex-encoded ciphertext with the wallet's ED25519 keypair."""
     try:
-        ciphertext = bytes.fromhex(
-            ciphertext_hex.strip().lower().removeprefix("0x")
-        )
+        ciphertext = bytes.fromhex(ciphertext_hex.strip().lower().removeprefix("0x"))
     except ValueError as e:
         err = f"Invalid ciphertext hex: {e}"
         if json_output:

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -36,6 +36,8 @@ from bittensor_cli.src.bittensor.utils import (
     CryptoType,
     confirm_action,
     console,
+    crypto_type_from_int,
+    crypto_type_tag,
     crypto_type_to_int,
     json_console,
     print_error,
@@ -906,22 +908,28 @@ async def wallet_list(
     root = Tree("Wallets")
     main_data_dict = {"wallets": []}
     for wallet in wallets:
+        coldkey_crypto: Optional[CryptoType] = None
         if (
             wallet.coldkeypub_file.exists_on_device()
             and os.path.isfile(wallet.coldkeypub_file.path)
             and not wallet.coldkeypub_file.is_encrypted()
         ):
             coldkeypub_str = wallet.coldkeypub.ss58_address
+            coldkey_crypto = crypto_type_from_int(wallet.coldkeypub.crypto_type)
+            coldkey_tag = f" {crypto_type_tag(wallet.coldkeypub.crypto_type)}"
         else:
             coldkeypub_str = "?"
+            coldkey_tag = ""
 
         wallet_tree = root.add(
-            f"[bold blue]Coldkey[/bold blue] [green]{wallet.name}[/green]  ss58_address [green]{coldkeypub_str}[/green]"
+            f"[bold blue]Coldkey[/bold blue] [green]{wallet.name}[/green]  "
+            f"ss58_address [green]{coldkeypub_str}[/green]{coldkey_tag}"
         )
         wallet_hotkeys = []
         wallet_dict = {
             "name": wallet.name,
             "ss58_address": coldkeypub_str,
+            "crypto_type": coldkey_crypto.value if coldkey_crypto else None,
             "hotkeys": wallet_hotkeys,
         }
         main_data_dict["wallets"].append(wallet_dict)
@@ -930,21 +938,31 @@ async def wallet_list(
         )
         for hkey in hotkeys:
             data = f"[bold red]Hotkey[/bold red][green] {hkey}[/green] (?)"
-            hk_data = {"name": hkey.name, "ss58_address": "?"}
+            hk_data = {"name": hkey.name, "ss58_address": "?", "crypto_type": None}
             if hkey:
                 try:
-                    hkey_ss58 = hkey.get_hotkey().ss58_address
+                    keypair = hkey.get_hotkey()
+                    hkey_ss58 = keypair.ss58_address
+                    hk_crypto_int: Optional[int] = keypair.crypto_type
                     pub_only = False
                 except KeyFileError:
-                    hkey_ss58 = hkey.get_hotkeypub().ss58_address
+                    keypair = hkey.get_hotkeypub()
+                    hkey_ss58 = keypair.ss58_address
+                    hk_crypto_int = keypair.crypto_type
                     pub_only = True
                 except AttributeError:
                     hkey_ss58 = hkey.hotkey.ss58_address
+                    hk_crypto_int = getattr(hkey.hotkey, "crypto_type", None)
                     pub_only = False
                 try:
+                    crypto_suffix = (
+                        f" {crypto_type_tag(hk_crypto_int)}"
+                        if hk_crypto_int is not None
+                        else ""
+                    )
                     data = (
                         f"[bold red]Hotkey[/bold red] [green]{hkey.hotkey_str}[/green]  "
-                        f"ss58_address [green]{hkey_ss58}[/green]"
+                        f"ss58_address [green]{hkey_ss58}[/green]{crypto_suffix}"
                     )
                     if pub_only:
                         data += " [blue](hotkeypub only)[/blue]\n"
@@ -952,6 +970,9 @@ async def wallet_list(
                         data += "\n"
                     hk_data["name"] = hkey.hotkey_str
                     hk_data["ss58_address"] = hkey_ss58
+                    if hk_crypto_int is not None:
+                        ct = crypto_type_from_int(hk_crypto_int)
+                        hk_data["crypto_type"] = ct.value if ct else None
                 except UnicodeDecodeError:
                     pass
             wallet_tree.add(data)

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -511,7 +511,12 @@ async def wallet_create(
 
     if uri:
         try:
-            # URI creates a single keypair shared by cold/hot; only one crypto_type can apply.
+            err = "Cannot use different crypto types with `wallet create --uri`: \nSince it derives a single keypair used by both the coldkey and hotkey"
+                print_error(err)
+                output_dict["error"] = err
+                if json_output:
+                    json_console.print(json.dumps(output_dict))
+                return
             keypair = Keypair.create_from_uri(uri, crypto_type=coldkey_crypto_type)
             wallet.set_coldkey(keypair=keypair, encrypt=False, overwrite=overwrite)
             wallet.set_coldkeypub(keypair=keypair, encrypt=False, overwrite=overwrite)

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -33,8 +33,10 @@ from bittensor_cli.src.bittensor.networking import int_to_ip
 from bittensor_cli.src.bittensor.subtensor_interface import SubtensorInterface
 from bittensor_cli.src.bittensor.utils import (
     RAO_PER_TAO,
+    CryptoType,
     confirm_action,
     console,
+    crypto_type_to_int,
     json_console,
     print_error,
     print_verbose,
@@ -511,7 +513,11 @@ async def wallet_create(
 
     if uri:
         try:
-            err = "Cannot use different crypto types with `wallet create --uri`: \nSince it derives a single keypair used by both the coldkey and hotkey"
+            if coldkey_crypto_type != hotkey_crypto_type:
+                err = (
+                    "Cannot use different crypto types with `wallet create --uri`: \n"
+                    "Since it derives a single keypair used by both the coldkey and hotkey"
+                )
                 print_error(err)
                 output_dict["error"] = err
                 if json_output:
@@ -2040,30 +2046,30 @@ async def verify(
     message: str,
     signature: str,
     public_key_or_ss58: str,
+    crypto_type: Optional[CryptoType] = None,
     json_output: bool = False,
 ):
-    """Verify a message signature using a public key or SS58 address."""
+    """Verify a message signature using a public key or SS58 address.
 
-    if is_valid_ss58_address(public_key_or_ss58):
+    If ``crypto_type`` is ``None``, both SR25519 and ED25519 are tried and the
+    matching scheme (if any) is reported back to the user.
+    """
+
+    use_ss58 = is_valid_ss58_address(public_key_or_ss58)
+    public_key_hex: Optional[str] = None
+    if use_ss58:
         print_verbose(f"[blue]SS58 address detected:[/blue] {public_key_or_ss58}")
-        keypair = Keypair(ss58_address=public_key_or_ss58)
-        signer_address = public_key_or_ss58
+        signer_address: Optional[str] = public_key_or_ss58
     else:
         try:
             public_key_hex = public_key_or_ss58.strip().lower()
             if public_key_hex.startswith("0x"):
                 public_key_hex = public_key_hex[2:]
-            if len(public_key_hex) == 64:
-                bytes.fromhex(public_key_hex)
-                print_verbose("[blue]Hex public key detected[/blue] (64 characters)")
-                keypair = Keypair(public_key=public_key_hex)
-                signer_address = keypair.ss58_address
-                print_verbose(
-                    f"[blue]Corresponding SS58 address:[/blue] {signer_address}"
-                )
-            else:
+            if len(public_key_hex) != 64:
                 raise ValueError("Public key must be 32 bytes (64 hex characters)")
-
+            bytes.fromhex(public_key_hex)
+            print_verbose("[blue]Hex public key detected[/blue] (64 characters)")
+            signer_address = None
         except (ValueError, TypeError) as e:
             if json_output:
                 json_console.print(
@@ -2096,20 +2102,51 @@ async def verify(
             print_error(f"Invalid signature format: {str(e)}")
         return False
 
-    is_valid = keypair.verify(message.encode("utf-8"), signature_bytes)
+    candidates = (
+        [crypto_type]
+        if crypto_type is not None
+        else [CryptoType.SR25519, CryptoType.ED25519]
+    )
+
+    is_valid = False
+    matched_type: Optional[CryptoType] = None
+    message_bytes = message.encode("utf-8")
+    for ct in candidates:
+        ct_int = crypto_type_to_int(ct)
+        if use_ss58:
+            kp = Keypair(ss58_address=public_key_or_ss58, crypto_type=ct_int)
+        else:
+            kp = Keypair(public_key=public_key_hex, crypto_type=ct_int)
+        if signer_address is None:
+            signer_address = kp.ss58_address
+            print_verbose(f"[blue]Corresponding SS58 address:[/blue] {signer_address}")
+        if kp.verify(message_bytes, signature_bytes):
+            is_valid = True
+            matched_type = ct
+            break
 
     if json_output:
-        json_console.print(
-            json.dumps(
-                {"verified": is_valid, "signer": signer_address, "message": message}
-            )
-        )
+        payload = {
+            "verified": is_valid,
+            "signer": signer_address,
+            "message": message,
+        }
+        if matched_type is not None:
+            payload["crypto_type"] = matched_type.value
+        json_console.print(json.dumps(payload))
     else:
         if is_valid:
             console.print("[dark_sea_green3]Signature is valid!\n")
             console.print(f"[yellow]Signer:[/yellow] {signer_address}")
+            assert matched_type is not None
+            console.print(f"[yellow]Crypto type:[/yellow] {matched_type.value}")
         else:
-            print_error("Signature verification failed!")
+            if crypto_type is None:
+                print_error(
+                    "Signature verification failed for both sr25519 and ed25519."
+                )
+            else:
+                print_error(f"Signature verification failed for {crypto_type.value}.")
 
     return is_valid
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,8 @@ dependencies = [
     "cyscale>=0.3.3,<1.0.0",
     "typer>=0.16",
     "typing_extensions>4.0.0; python_version<'3.11'",
-    "bittensor-wallet==4.0.1",
+    # TODO change to bittensor-wallet==4.1.0 when released
+    "bittensor-wallet @ git+https://github.com/opentensor/btwallet.git@staging",
     "packaging",
     "plotille>=5.0.0",
     "plotly>=6.0.0",

--- a/tests/unit_tests/test_crypto_type_passthrough.py
+++ b/tests/unit_tests/test_crypto_type_passthrough.py
@@ -1,0 +1,124 @@
+"""Tests that --crypto-type is plumbed through to bittensor_wallet calls."""
+
+import json
+
+import pytest
+from unittest.mock import MagicMock, patch
+from bittensor_wallet import CRYPTO_ED25519, CRYPTO_SR25519, Keypair
+
+from bittensor_cli.src.bittensor.utils import CryptoType, crypto_type_to_int
+
+
+MODULE = "bittensor_cli.src.commands.wallets"
+
+
+class TestCryptoTypeEnum:
+    def test_str_values(self):
+        assert CryptoType.SR25519.value == "sr25519"
+        assert CryptoType.ED25519.value == "ed25519"
+
+    def test_mapping_to_int(self):
+        assert crypto_type_to_int(CryptoType.SR25519) == CRYPTO_SR25519
+        assert crypto_type_to_int(CryptoType.ED25519) == CRYPTO_ED25519
+
+
+class TestNewColdkeyCryptoType:
+    @pytest.mark.asyncio
+    async def test_passes_crypto_type_to_create_new_coldkey(self, mock_wallet):
+        from bittensor_cli.src.commands.wallets import new_coldkey
+
+        await new_coldkey(
+            wallet=mock_wallet,
+            n_words=12,
+            use_password=False,
+            uri=None,
+            json_output=False,
+            crypto_type=CRYPTO_ED25519,
+        )
+        mock_wallet.create_new_coldkey.assert_called_once()
+        kwargs = mock_wallet.create_new_coldkey.call_args.kwargs
+        assert kwargs["crypto_type"] == CRYPTO_ED25519
+
+    @pytest.mark.asyncio
+    async def test_passes_crypto_type_to_create_from_uri(self, mock_wallet):
+        from bittensor_cli.src.commands.wallets import new_coldkey
+
+        fake_kp = MagicMock(spec=Keypair)
+        with patch.object(
+            Keypair, "create_from_uri", return_value=fake_kp
+        ) as mock_from_uri:
+            await new_coldkey(
+                wallet=mock_wallet,
+                n_words=12,
+                use_password=False,
+                uri="//Alice",
+                json_output=False,
+                crypto_type=CRYPTO_ED25519,
+            )
+        mock_from_uri.assert_called_once_with("//Alice", crypto_type=CRYPTO_ED25519)
+
+
+class TestNewHotkeyCryptoType:
+    @pytest.mark.asyncio
+    async def test_passes_crypto_type_to_create_new_hotkey(self, mock_wallet):
+        from bittensor_cli.src.commands.wallets import new_hotkey
+
+        await new_hotkey(
+            wallet=mock_wallet,
+            n_words=12,
+            use_password=False,
+            uri=None,
+            json_output=False,
+            crypto_type=CRYPTO_ED25519,
+        )
+        kwargs = mock_wallet.create_new_hotkey.call_args.kwargs
+        assert kwargs["crypto_type"] == CRYPTO_ED25519
+
+
+class TestRegenColdkeyCryptoType:
+    @pytest.mark.asyncio
+    async def test_passes_crypto_type_to_regenerate_coldkey(self, mock_wallet):
+        from bittensor_cli.src.commands.wallets import regen_coldkey
+
+        mock_wallet.regenerate_coldkey.return_value = mock_wallet
+        await regen_coldkey(
+            wallet=mock_wallet,
+            mnemonic="m1 m2 m3 m4 m5 m6 m7 m8 m9 m10 m11 m12",
+            json_output=False,
+            crypto_type=CRYPTO_ED25519,
+        )
+        kwargs = mock_wallet.regenerate_coldkey.call_args.kwargs
+        assert kwargs["crypto_type"] == CRYPTO_ED25519
+
+
+class TestRegenColdkeyPubCryptoType:
+    @pytest.mark.asyncio
+    async def test_passes_crypto_type_to_regenerate_coldkeypub(self, mock_wallet):
+        from bittensor_cli.src.commands.wallets import regen_coldkey_pub
+
+        mock_wallet.regenerate_coldkeypub.return_value = mock_wallet
+        await regen_coldkey_pub(
+            wallet=mock_wallet,
+            ss58_address="5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+            public_key_hex=None,
+            crypto_type=CRYPTO_ED25519,
+        )
+        kwargs = mock_wallet.regenerate_coldkeypub.call_args.kwargs
+        assert kwargs["crypto_type"] == CRYPTO_ED25519
+
+
+class TestWalletCreateSplitCryptoTypes:
+    @pytest.mark.asyncio
+    async def test_passes_split_crypto_types(self, mock_wallet):
+        from bittensor_cli.src.commands.wallets import wallet_create
+
+        await wallet_create(
+            wallet=mock_wallet,
+            json_output=False,
+            coldkey_crypto_type=CRYPTO_ED25519,
+            hotkey_crypto_type=CRYPTO_SR25519,
+        )
+        cold_kwargs = mock_wallet.create_new_coldkey.call_args.kwargs
+        hot_kwargs = mock_wallet.create_new_hotkey.call_args.kwargs
+        assert cold_kwargs["crypto_type"] == CRYPTO_ED25519
+        assert hot_kwargs["crypto_type"] == CRYPTO_SR25519

--- a/tests/unit_tests/test_wallet_encrypt_decrypt.py
+++ b/tests/unit_tests/test_wallet_encrypt_decrypt.py
@@ -132,9 +132,7 @@ class TestDecryptMessage:
             patch(f"{MODULE}.unlock_key", return_value=unlock_result) as mock_unlock,
             patch(f"{MODULE}.json_console"),
         ):
-            await decrypt_message(
-                mock_wallet, "00", use_hotkey=True, json_output=True
-            )
+            await decrypt_message(mock_wallet, "00", use_hotkey=True, json_output=True)
         # unlock_key called with "hot" not "cold"
         assert mock_unlock.call_args[0][1] == "hot"
         mock_wallet.hotkey.decrypt.assert_called_once()

--- a/tests/unit_tests/test_wallet_encrypt_decrypt.py
+++ b/tests/unit_tests/test_wallet_encrypt_decrypt.py
@@ -1,0 +1,140 @@
+"""Tests for `btcli wallet encrypt` / `btcli wallet decrypt`."""
+
+import json
+
+import pytest
+from unittest.mock import MagicMock, patch
+from bittensor_wallet import CRYPTO_ED25519, CRYPTO_SR25519, Keypair
+
+
+MODULE = "bittensor_cli.src.commands.wallets"
+
+VALID_ED25519_SS58 = "5FjpRbCZbsasWaaXweGhLM7R5F6kYxWcXdVF8wYPvQhxXL8w"
+
+
+# ---------------------------------------------------------------------------
+# encrypt_message
+# ---------------------------------------------------------------------------
+
+
+class TestEncryptMessage:
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_ss58(self):
+        from bittensor_cli.src.commands.wallets import encrypt_message
+
+        with patch(f"{MODULE}.print_error") as mock_err:
+            result = await encrypt_message("not-an-ss58", "hi", json_output=False)
+        assert result is False
+        mock_err.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_calls_encrypt_for_with_ed25519(self):
+        from bittensor_cli.src.commands.wallets import encrypt_message
+
+        with patch.object(
+            Keypair, "encrypt_for", return_value=b"\x01\x02\x03"
+        ) as mock_ef:
+            result = await encrypt_message(VALID_ED25519_SS58, "hi", json_output=True)
+        assert result is True
+        mock_ef.assert_called_once_with(VALID_ED25519_SS58, b"hi", CRYPTO_ED25519)
+
+    @pytest.mark.asyncio
+    async def test_json_output_includes_hex(self):
+        from bittensor_cli.src.commands.wallets import encrypt_message
+
+        with (
+            patch.object(Keypair, "encrypt_for", return_value=b"\xaa\xbb"),
+            patch(f"{MODULE}.json_console") as mock_json,
+        ):
+            await encrypt_message(VALID_ED25519_SS58, "hi", json_output=True)
+        output = json.loads(mock_json.print.call_args[0][0])
+        assert output["success"] is True
+        assert output["data"]["ciphertext_hex"] == "aabb"
+        assert output["data"]["recipient"] == VALID_ED25519_SS58
+
+
+# ---------------------------------------------------------------------------
+# decrypt_message
+# ---------------------------------------------------------------------------
+
+
+class TestDecryptMessage:
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_hex(self, mock_wallet):
+        from bittensor_cli.src.commands.wallets import decrypt_message
+
+        with patch(f"{MODULE}.print_error") as mock_err:
+            result = await decrypt_message(
+                mock_wallet, "not-hex!!", use_hotkey=False, json_output=False
+            )
+        assert result is False
+        mock_err.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_unlock_fails(self, mock_wallet):
+        from bittensor_cli.src.commands.wallets import decrypt_message
+
+        unlock_result = MagicMock()
+        unlock_result.success = False
+        with patch(f"{MODULE}.unlock_key", return_value=unlock_result):
+            result = await decrypt_message(
+                mock_wallet, "deadbeef", use_hotkey=False, json_output=False
+            )
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_rejects_sr25519_coldkey(self, mock_wallet):
+        from bittensor_cli.src.commands.wallets import decrypt_message
+
+        unlock_result = MagicMock()
+        unlock_result.success = True
+        mock_wallet.coldkey.crypto_type = CRYPTO_SR25519
+        with (
+            patch(f"{MODULE}.unlock_key", return_value=unlock_result),
+            patch(f"{MODULE}.print_error") as mock_err,
+        ):
+            result = await decrypt_message(
+                mock_wallet, "deadbeef", use_hotkey=False, json_output=False
+            )
+        assert result is False
+        assert "ED25519" in mock_err.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_decrypts_with_ed25519_coldkey(self, mock_wallet):
+        from bittensor_cli.src.commands.wallets import decrypt_message
+
+        unlock_result = MagicMock()
+        unlock_result.success = True
+        mock_wallet.coldkey.crypto_type = CRYPTO_ED25519
+        mock_wallet.coldkey.decrypt = MagicMock(return_value=b"hello")
+        with (
+            patch(f"{MODULE}.unlock_key", return_value=unlock_result),
+            patch(f"{MODULE}.json_console") as mock_json,
+        ):
+            result = await decrypt_message(
+                mock_wallet, "0xdeadbeef", use_hotkey=False, json_output=True
+            )
+        assert result is True
+        mock_wallet.coldkey.decrypt.assert_called_once_with(b"\xde\xad\xbe\xef")
+        output = json.loads(mock_json.print.call_args[0][0])
+        assert output["success"] is True
+        assert output["data"]["plaintext"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_uses_hotkey_when_requested(self, mock_wallet):
+        from bittensor_cli.src.commands.wallets import decrypt_message
+
+        unlock_result = MagicMock()
+        unlock_result.success = True
+        mock_wallet.hotkey.crypto_type = CRYPTO_ED25519
+        mock_wallet.hotkey.decrypt = MagicMock(return_value=b"world")
+        with (
+            patch(f"{MODULE}.unlock_key", return_value=unlock_result) as mock_unlock,
+            patch(f"{MODULE}.json_console"),
+        ):
+            await decrypt_message(
+                mock_wallet, "00", use_hotkey=True, json_output=True
+            )
+        # unlock_key called with "hot" not "cold"
+        assert mock_unlock.call_args[0][1] == "hot"
+        mock_wallet.hotkey.decrypt.assert_called_once()


### PR DESCRIPTION
Supports:
- SR25519 (default) and ED25519 for key creation
- Encrypt/Decrypt

**DO NOT MERGE UNTIL BT-WALLET 4.1.0 RELEASES**

When 4.1.0 releases, the pinned `@staging` in the pyproject.toml will need to be changed to `bittensor-wallet==4.1.0`