### PR TITLE
Supports new Typer release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "typing_extensions>4.0.0; python_version<'3.11'",
     # TODO change to bittensor-wallet==4.1.0 when released
     "bittensor-wallet @ git+https://github.com/opentensor/btwallet.git@staging",
-    "packaging",
     "plotille>=5.0.0",
     "plotly>=6.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,9 +36,9 @@ dependencies = [
     "netaddr~=1.3.0",
     "Jinja2",
     "PyYAML~=6.0",
-    "rich>=13.7,<15.0",
+    "rich>=15.0,<16.0",
     "cyscale>=0.3.3,<1.0.0",
-    "typer>=0.16",
+    "typer~=0.26.0",
     "typing_extensions>4.0.0; python_version<'3.11'",
     # TODO change to bittensor-wallet==4.1.0 when released
     "bittensor-wallet @ git+https://github.com/opentensor/btwallet.git@staging",

--- a/tests/e2e_tests/test_wallet_creations.py
+++ b/tests/e2e_tests/test_wallet_creations.py
@@ -136,7 +136,7 @@ def extract_json(output: str) -> dict:
 
     bittensor-wallet may prepend a human-readable mnemonic warning to stdout
     when built with the ``python-bindings`` feature (it routes prints through
-    Python's ``sys.stdout``, which Click's ``CliRunner`` captures into
+    Python's ``sys.stdout``, which Typer's ``CliRunner`` captures into
     ``result.stdout``). The published 4.0.1 wheel writes that warning to the
     OS-level fd 1 instead, so ``result.stdout`` is clean. Strip whatever
     prefix is present and decode the JSON object that btcli emitted.
@@ -422,7 +422,7 @@ def test_wallet_regen(wallet_setup, capfd):
 
     # Depending on how bittensor-wallet was built, the mnemonic is printed either
     # to the OS-level stdout (Rust `print!`, captured by capfd) or to Python's
-    # sys.stdout (pyo3 `python-bindings` feature, captured by Click's CliRunner
+    # sys.stdout (pyo3 `python-bindings` feature, captured by Typer's CliRunner
     # into result.stdout). Read both so the test is robust to either build.
     captured = capfd.readouterr()
     mnemonics = extract_mnemonics_from_commands(captured.out + (result.stdout or ""))

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -10,9 +10,8 @@ import time
 from typing import TYPE_CHECKING, Optional, Protocol
 
 from bittensor_wallet import Keypair, Wallet
-from click.testing import Result
 from packaging.version import parse as parse_version, Version
-from typer.testing import CliRunner
+from typer.testing import CliRunner, Result
 
 from bittensor_cli.cli import CLIManager
 

--- a/tests/e2e_tests/utils.py
+++ b/tests/e2e_tests/utils.py
@@ -1,5 +1,4 @@
 import asyncio
-import importlib
 import inspect
 import os
 import re
@@ -10,7 +9,6 @@ import time
 from typing import TYPE_CHECKING, Optional, Protocol
 
 from bittensor_wallet import Keypair, Wallet
-from packaging.version import parse as parse_version, Version
 from typer.testing import CliRunner, Result
 
 from bittensor_cli.cli import CLIManager
@@ -72,10 +70,7 @@ def setup_wallet(uri: str) -> tuple[Keypair, Wallet, str, ExecCommand]:
                             extra_args.extend(["--network", "ws://127.0.0.1:9945"])
 
         # Capture stderr separately from stdout
-        if parse_version(importlib.metadata.version("click")) < Version("8.2.0"):
-            runner = CliRunner(mix_stderr=False)
-        else:
-            runner = CliRunner()
+        runner = CliRunner()
         # Prepare the command arguments
         args = [
             command,


### PR DESCRIPTION
typer==0.26 drops Click as an external dependency, bumps Rich to 15.0, removes `packaging` (was used to set the CliRunner depending on the installed Click version)

~pins the typer version 