### PR TITLE
Update requirements for bittensor-wallet release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,8 +40,7 @@ dependencies = [
     "cyscale>=0.3.3,<1.0.0",
     "typer~=0.26.0",
     "typing_extensions>4.0.0; python_version<'3.11'",
-    # TODO change to bittensor-wallet==4.1.0 when released
-    "bittensor-wallet @ git+https://github.com/opentensor/btwallet.git@staging",
+    "bittensor-wallet==4.1.0",
     "plotille>=5.0.0",
     "plotly>=6.0.0",
 ]


### PR DESCRIPTION
~~Do not merge til 4.1.0 releases.~~

Update: released