### PR TITLE
feat: reintroduce --announce-only for stake, liquidity, and crowd commands (#898)Feat/announce only stake liquidity crowd

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -9610,6 +9610,7 @@ class CLIManager:
 
     def crowd_create(
         self,
+        announce_only: bool = Options.announce_only,
         network: Optional[list[str]] = Options.network,
         wallet_name: str = Options.wallet_name,
         wallet_path: str = Options.wallet_path,
@@ -9710,7 +9711,7 @@ class CLIManager:
         [green]$[/green] btcli crowd create --deposit 10 --cap 1000 --duration 1000 --min-contribution 1 --custom-call-pallet "SomeModule" --custom-call-method "some_method" --custom-call-args '{"param1": "value", "param2": 42}'
         """
         self.verbosity_handler(quiet, verbose, json_output, prompt)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
         wallet = self.wallet_ask(
             wallet_name=wallet_name,
             wallet_path=wallet_path,
@@ -9721,6 +9722,7 @@ class CLIManager:
 
         return self._run_command(
             create_crowdloan.create_crowdloan(
+                announce_only=announce_only,
                 subtensor=self.initialize_chain(network),
                 wallet=wallet,
                 proxy=proxy,
@@ -9744,6 +9746,7 @@ class CLIManager:
 
     def crowd_contribute(
         self,
+        announce_only: bool = Options.announce_only,
         crowdloan_id: Optional[int] = typer.Option(
             None,
             "--crowdloan-id",
@@ -9782,7 +9785,7 @@ class CLIManager:
         [green]$[/green] btcli crowd contribute --id 1
         """
         self.verbosity_handler(quiet, verbose, json_output, prompt)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
         if crowdloan_id is None:
             crowdloan_id = IntPrompt.ask(
                 f"Enter the [{COLORS.G.SUBHEAD_MAIN}]crowdloan id[/{COLORS.G.SUBHEAD_MAIN}]",
@@ -9800,6 +9803,7 @@ class CLIManager:
 
         return self._run_command(
             crowd_contribute.contribute_to_crowdloan(
+                announce_only=announce_only,
                 subtensor=self.initialize_chain(network),
                 wallet=wallet,
                 proxy=proxy,
@@ -9814,6 +9818,7 @@ class CLIManager:
 
     def crowd_withdraw(
         self,
+        announce_only: bool = Options.announce_only,
         crowdloan_id: Optional[int] = typer.Option(
             None,
             "--crowdloan-id",
@@ -9840,7 +9845,7 @@ class CLIManager:
         Creators can only withdraw amounts above their initial deposit.
         """
         self.verbosity_handler(quiet, verbose, json_output, prompt)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
         if crowdloan_id is None:
             crowdloan_id = IntPrompt.ask(
                 f"Enter the [{COLORS.G.SUBHEAD_MAIN}]crowdloan id[/{COLORS.G.SUBHEAD_MAIN}]",
@@ -9858,6 +9863,7 @@ class CLIManager:
 
         return self._run_command(
             crowd_contribute.withdraw_from_crowdloan(
+                announce_only=announce_only,
                 subtensor=self.initialize_chain(network),
                 wallet=wallet,
                 proxy=proxy,
@@ -9871,6 +9877,7 @@ class CLIManager:
 
     def crowd_finalize(
         self,
+        announce_only: bool = Options.announce_only,
         crowdloan_id: Optional[int] = typer.Option(
             None,
             "--crowdloan-id",
@@ -9897,7 +9904,7 @@ class CLIManager:
         address (if specified) and execute any attached call (e.g., subnet creation).
         """
         self.verbosity_handler(quiet, verbose, json_output, prompt)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
         if crowdloan_id is None:
             crowdloan_id = IntPrompt.ask(
                 f"Enter the [{COLORS.G.SUBHEAD_MAIN}]crowdloan id[/{COLORS.G.SUBHEAD_MAIN}]",
@@ -9915,6 +9922,7 @@ class CLIManager:
 
         return self._run_command(
             create_crowdloan.finalize_crowdloan(
+                announce_only=announce_only,
                 subtensor=self.initialize_chain(network),
                 wallet=wallet,
                 crowdloan_id=crowdloan_id,
@@ -9928,6 +9936,7 @@ class CLIManager:
 
     def crowd_update(
         self,
+        announce_only: bool = Options.announce_only,
         crowdloan_id: Optional[int] = typer.Option(
             None,
             "--crowdloan-id",
@@ -9974,7 +9983,7 @@ class CLIManager:
         bounds, etc.).
         """
         self.verbosity_handler(quiet, verbose, json_output, prompt)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
         if crowdloan_id is None:
             crowdloan_id = IntPrompt.ask(
                 f"Enter the [{COLORS.G.SUBHEAD_MAIN}]crowdloan id[/{COLORS.G.SUBHEAD_MAIN}]",
@@ -9997,6 +10006,7 @@ class CLIManager:
 
         return self._run_command(
             crowd_update.update_crowdloan(
+                announce_only=announce_only,
                 subtensor=self.initialize_chain(network),
                 wallet=wallet,
                 proxy=proxy,
@@ -10013,6 +10023,7 @@ class CLIManager:
 
     def crowd_refund(
         self,
+        announce_only: bool = Options.announce_only,
         crowdloan_id: Optional[int] = typer.Option(
             None,
             "--crowdloan-id",
@@ -10041,7 +10052,7 @@ class CLIManager:
         Contributors can call `btcli crowdloan withdraw` at will.
         """
         self.verbosity_handler(quiet, verbose, json_output, prompt)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
         if crowdloan_id is None:
             crowdloan_id = IntPrompt.ask(
                 f"Enter the [{COLORS.G.SUBHEAD_MAIN}]crowdloan id[/{COLORS.G.SUBHEAD_MAIN}]",
@@ -10059,6 +10070,7 @@ class CLIManager:
 
         return self._run_command(
             crowd_refund.refund_crowdloan(
+                announce_only=announce_only,
                 subtensor=self.initialize_chain(network),
                 wallet=wallet,
                 proxy=proxy,
@@ -10072,6 +10084,7 @@ class CLIManager:
 
     def crowd_dissolve(
         self,
+        announce_only: bool = Options.announce_only,
         crowdloan_id: Optional[int] = typer.Option(
             None,
             "--crowdloan-id",
@@ -10103,7 +10116,7 @@ class CLIManager:
         you can run `btcli crowd refund` to refund the remaining contributors.
         """
         self.verbosity_handler(quiet, verbose, json_output, prompt)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
         if crowdloan_id is None:
             crowdloan_id = IntPrompt.ask(
                 f"Enter the [{COLORS.G.SUBHEAD_MAIN}]crowdloan id[/{COLORS.G.SUBHEAD_MAIN}]",
@@ -10121,6 +10134,7 @@ class CLIManager:
 
         return self._run_command(
             crowd_dissolve.dissolve_crowdloan(
+                announce_only=announce_only,
                 subtensor=self.initialize_chain(network),
                 wallet=wallet,
                 proxy=proxy,

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -2318,6 +2318,37 @@ class CLIManager:
             raise typer.BadParameter(f"Invalid SS58 address: {address}")
         return address
 
+    def _resolve_mev_for_announce(
+        self,
+        ctx: Optional[typer.Context],
+        announce_only: bool,
+        mev_protection: bool,
+    ) -> bool:
+        """Reconcile ``--announce-only`` with ``--mev-protection``.
+
+        An announcement submits a plain ``Proxy.announce`` of the call hash, which cannot be
+        wrapped in the MEV shield (the shield is applied later, when the announced call is
+        actually executed). MEV protection defaults to on, so:
+          - if the user explicitly passed ``--mev-protection``, raise a clear error;
+          - otherwise silently disable it for the announcement and note it.
+
+        Returns the ``mev_protection`` value that should be used downstream.
+        """
+        if not (announce_only and mev_protection):
+            return mev_protection
+        source = ctx.get_parameter_source("mev_protection") if ctx is not None else None
+        if source is not None and source.name == "COMMANDLINE":
+            raise typer.BadParameter(
+                "--announce-only cannot be combined with --mev-protection. MEV protection is "
+                "applied when the announced call is executed, not when it is announced. "
+                "Re-run without --mev-protection."
+            )
+        console.print(
+            "[dim]Note: --mev-protection does not apply to an announcement; it will be "
+            "applied when the announced call is executed.[/dim]"
+        )
+        return False
+
     def ask_rate_tolerance(
         self,
         rate_tolerance: Optional[float],
@@ -5151,6 +5182,8 @@ class CLIManager:
 
     def stake_add(
         self,
+        ctx: typer.Context = None,
+        announce_only: bool = Options.announce_only,
         stake_all: bool = typer.Option(
             False,
             "--all-tokens",
@@ -5241,7 +5274,10 @@ class CLIManager:
         """
         netuids = netuids or []
         self.verbosity_handler(quiet, verbose, json_output, prompt, decline)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
+        mev_protection = self._resolve_mev_for_announce(
+            ctx, announce_only, mev_protection
+        )
         safe_staking = self.ask_safe_staking(safe_staking)
         if safe_staking:
             rate_tolerance = self.ask_rate_tolerance(rate_tolerance)
@@ -5452,6 +5488,7 @@ class CLIManager:
         )
         return self._run_command(
             add_stake.stake_add(
+                announce_only=announce_only,
                 wallet=wallet,
                 subtensor=self.initialize_chain(network),
                 netuids=netuids,
@@ -5475,6 +5512,8 @@ class CLIManager:
 
     def stake_remove(
         self,
+        ctx: typer.Context = None,
+        announce_only: bool = Options.announce_only,
         network: Optional[list[str]] = Options.network,
         wallet_name: str = Options.wallet_name,
         wallet_path: str = Options.wallet_path,
@@ -5570,7 +5609,10 @@ class CLIManager:
         • [blue]--partial[/blue]: Complete partial unstake if rates exceed tolerance
         """
         self.verbosity_handler(quiet, verbose, json_output, prompt, decline)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
+        mev_protection = self._resolve_mev_for_announce(
+            ctx, announce_only, mev_protection
+        )
         if not unstake_all and not unstake_all_alpha:
             safe_staking = self.ask_safe_staking(safe_staking)
             if safe_staking:
@@ -5746,6 +5788,7 @@ class CLIManager:
             )
             return self._run_command(
                 remove_stake.unstake_all(
+                    announce_only=announce_only,
                     wallet=wallet,
                     subtensor=self.initialize_chain(network),
                     hotkey_ss58_address=hotkey_ss58_address,
@@ -5818,6 +5861,7 @@ class CLIManager:
 
         return self._run_command(
             remove_stake.unstake(
+                announce_only=announce_only,
                 wallet=wallet,
                 subtensor=self.initialize_chain(network),
                 hotkey_ss58_address=hotkey_ss58_address,
@@ -5842,6 +5886,8 @@ class CLIManager:
 
     def stake_move(
         self,
+        ctx: typer.Context = None,
+        announce_only: bool = Options.announce_only,
         network: Optional[list[str]] = Options.network,
         wallet_name: Optional[str] = Options.wallet_name,
         wallet_path: Optional[str] = Options.wallet_path,
@@ -5915,7 +5961,10 @@ class CLIManager:
             [green]$[/green] btcli stake move --no-mev-protection
         """
         self.verbosity_handler(quiet, verbose, json_output, prompt, decline)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
+        mev_protection = self._resolve_mev_for_announce(
+            ctx, announce_only, mev_protection
+        )
         print_protection_warnings(
             mev_protection=mev_protection,
             safe_staking=None,
@@ -6026,6 +6075,7 @@ class CLIManager:
         )
         result, ext_id = self._run_command(
             move_stake.move_stake(
+                announce_only=announce_only,
                 subtensor=self.initialize_chain(network),
                 wallet=wallet,
                 origin_netuid=origin_netuid,
@@ -6051,6 +6101,8 @@ class CLIManager:
 
     def stake_transfer(
         self,
+        ctx: typer.Context = None,
+        announce_only: bool = Options.announce_only,
         network: Optional[list[str]] = Options.network,
         wallet_name: Optional[str] = Options.wallet_name,
         wallet_path: Optional[str] = Options.wallet_path,
@@ -6126,7 +6178,10 @@ class CLIManager:
         [green]$[/green] btcli stake transfer --origin-netuid 1 --dest-netuid 2 --amount 100 --no-mev-protection
         """
         self.verbosity_handler(quiet, verbose, json_output, prompt, decline)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
+        mev_protection = self._resolve_mev_for_announce(
+            ctx, announce_only, mev_protection
+        )
         print_protection_warnings(
             mev_protection=mev_protection,
             safe_staking=None,
@@ -6233,6 +6288,7 @@ class CLIManager:
         )
         result, ext_id = self._run_command(
             move_stake.transfer_stake(
+                announce_only=announce_only,
                 wallet=wallet,
                 subtensor=self.initialize_chain(network),
                 origin_hotkey=origin_hotkey,
@@ -6258,6 +6314,8 @@ class CLIManager:
 
     def stake_swap(
         self,
+        ctx: typer.Context = None,
+        announce_only: bool = Options.announce_only,
         network: Optional[list[str]] = Options.network,
         wallet_name: Optional[str] = Options.wallet_name,
         wallet_path: Optional[str] = Options.wallet_path,
@@ -6332,7 +6390,10 @@ class CLIManager:
             [green]$[/green] btcli stake swap --origin-netuid 1 --dest-netuid 2 --amount 100 --unsafe
         """
         self.verbosity_handler(quiet, verbose, json_output, prompt, decline)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
+        mev_protection = self._resolve_mev_for_announce(
+            ctx, announce_only, mev_protection
+        )
         console.print(
             "[dim]This command moves stake from one subnet to another subnet while keeping "
             "the same coldkey-hotkey pair.[/dim]"
@@ -6390,6 +6451,7 @@ class CLIManager:
         )
         result, ext_id = self._run_command(
             move_stake.swap_stake(
+                announce_only=announce_only,
                 wallet=wallet,
                 subtensor=self.initialize_chain(network),
                 origin_netuid=origin_netuid,

--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -9070,6 +9070,7 @@ class CLIManager:
         wallet_hotkey: str = Options.wallet_hotkey,
         netuid: Optional[int] = Options.netuid,
         proxy: Optional[str] = Options.proxy,
+        announce_only: bool = Options.announce_only,
         liquidity_: Optional[float] = typer.Option(
             None,
             "--liquidity",
@@ -9099,7 +9100,7 @@ class CLIManager:
     ):
         """Add liquidity to the swap (as a combination of TAO + Alpha)."""
         self.verbosity_handler(quiet, verbose, json_output, prompt, decline)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
         if not netuid:
             netuid = Prompt.ask(
                 f"Enter the [{COLORS.G.SUBHEAD_MAIN}]netuid[/{COLORS.G.SUBHEAD_MAIN}] to use",
@@ -9160,6 +9161,7 @@ class CLIManager:
                 decline=decline,
                 quiet=quiet,
                 json_output=json_output,
+                announce_only=announce_only,
             )
         )
 
@@ -9207,6 +9209,7 @@ class CLIManager:
         wallet_hotkey: str = Options.wallet_hotkey,
         netuid: Optional[int] = Options.netuid,
         proxy: Optional[str] = Options.proxy,
+        announce_only: bool = Options.announce_only,
         position_id: Optional[int] = typer.Option(
             None,
             "--position-id",
@@ -9228,7 +9231,7 @@ class CLIManager:
         """Remove liquidity from the swap (as a combination of TAO + Alpha)."""
 
         self.verbosity_handler(quiet, verbose, json_output, prompt, decline)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
         if all_liquidity_ids and position_id:
             print_error("Cannot specify both --all and --position-id.")
             return
@@ -9272,6 +9275,7 @@ class CLIManager:
                 quiet=quiet,
                 all_liquidity_ids=all_liquidity_ids,
                 json_output=json_output,
+                announce_only=announce_only,
             )
         )
 
@@ -9283,6 +9287,7 @@ class CLIManager:
         wallet_hotkey: str = Options.wallet_hotkey,
         netuid: Optional[int] = Options.netuid,
         proxy: Optional[str] = Options.proxy,
+        announce_only: bool = Options.announce_only,
         position_id: Optional[int] = typer.Option(
             None,
             "--position-id",
@@ -9303,7 +9308,7 @@ class CLIManager:
     ):
         """Modifies the liquidity position for the given subnet."""
         self.verbosity_handler(quiet, verbose, json_output, prompt, decline)
-        proxy = self.is_valid_proxy_name_or_ss58(proxy, False)
+        proxy = self.is_valid_proxy_name_or_ss58(proxy, announce_only)
         if not netuid:
             netuid = IntPrompt.ask(
                 f"Enter the [{COLORS.G.SUBHEAD_MAIN}]netuid[/{COLORS.G.SUBHEAD_MAIN}] to use",
@@ -9352,6 +9357,7 @@ class CLIManager:
                 decline=decline,
                 quiet=quiet,
                 json_output=json_output,
+                announce_only=announce_only,
             )
         )
 

--- a/bittensor_cli/src/commands/crowd/contribute.py
+++ b/bittensor_cli/src/commands/crowd/contribute.py
@@ -297,6 +297,8 @@ async def contribute_to_crowdloan(
                     }
                 )
             )
+        else:
+            console.print("[green]Announcement submitted[/green] — not executed yet.")
         return True, "Crowdloan contribution announcement submitted."
 
     new_balance, new_contribution, updated_crowdloan = await asyncio.gather(
@@ -610,6 +612,8 @@ async def withdraw_from_crowdloan(
                     }
                 )
             )
+        else:
+            console.print("[green]Announcement submitted[/green] — not executed yet.")
         return True, "Crowdloan withdrawal announcement submitted."
 
     new_balance, updated_contribution, updated_crowdloan = await asyncio.gather(

--- a/bittensor_cli/src/commands/crowd/contribute.py
+++ b/bittensor_cli/src/commands/crowd/contribute.py
@@ -59,6 +59,7 @@ async def contribute_to_crowdloan(
     crowdloan_id: int,
     amount: Optional[float],
     prompt: bool,
+    announce_only: bool = False,
     decline: bool = False,
     quiet: bool = False,
     wait_for_inclusion: bool = True,
@@ -218,6 +219,12 @@ async def contribute_to_crowdloan(
         f"[blue]{user_balance}[/blue] → [{COLORS.S.AMOUNT}]{updated_balance}[/{COLORS.S.AMOUNT}]",
     )
     console.print(table)
+    if announce_only:
+        console.print(
+            "[dim]Note: with --announce-only the call is not executed now. These figures "
+            "reflect the current chain state and may differ when the announced call is "
+            "executed.[/dim]"
+        )
 
     if will_be_adjusted:
         console.print(
@@ -260,6 +267,7 @@ async def contribute_to_crowdloan(
             proxy=proxy,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
+            announce_only=announce_only,
         )
 
     if not success:
@@ -275,6 +283,21 @@ async def contribute_to_crowdloan(
         else:
             print_error(f"Failed to contribute: {error_message}")
         return False, error_message or "Failed to contribute."
+
+    if announce_only:
+        if json_output:
+            announce_id = await extrinsic_receipt.get_extrinsic_identifier()
+            json_console.print(
+                json.dumps(
+                    {
+                        "success": True,
+                        "error": None,
+                        "announce_only": True,
+                        "extrinsic_identifier": announce_id,
+                    }
+                )
+            )
+        return True, "Crowdloan contribution announcement submitted."
 
     new_balance, new_contribution, updated_crowdloan = await asyncio.gather(
         subtensor.get_balance(contributor_address),
@@ -365,6 +388,7 @@ async def withdraw_from_crowdloan(
     wait_for_inclusion: bool,
     wait_for_finalization: bool,
     prompt: bool,
+    announce_only: bool = False,
     decline: bool = False,
     quiet: bool = False,
     json_output: bool = False,
@@ -515,6 +539,12 @@ async def withdraw_from_crowdloan(
         )
 
         console.print(table)
+        if announce_only:
+            console.print(
+                "[dim]Note: with --announce-only the call is not executed now. These "
+                "figures reflect the current chain state and may differ when the "
+                "announced call is executed.[/dim]"
+            )
 
         if not confirm_action(
             "\nProceed with withdrawal?", decline=decline, quiet=quiet
@@ -550,6 +580,7 @@ async def withdraw_from_crowdloan(
             proxy=proxy,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
+            announce_only=announce_only,
         )
 
     if not success:
@@ -565,6 +596,21 @@ async def withdraw_from_crowdloan(
         else:
             print_error(f"Failed to withdraw: {error_message or 'Unknown error'}")
         return False, error_message or "Failed to withdraw from crowdloan."
+
+    if announce_only:
+        if json_output:
+            announce_id = await extrinsic_receipt.get_extrinsic_identifier()
+            json_console.print(
+                json.dumps(
+                    {
+                        "success": True,
+                        "error": None,
+                        "announce_only": True,
+                        "extrinsic_identifier": announce_id,
+                    }
+                )
+            )
+        return True, "Crowdloan withdrawal announcement submitted."
 
     new_balance, updated_contribution, updated_crowdloan = await asyncio.gather(
         subtensor.get_balance(contributor_address),

--- a/bittensor_cli/src/commands/crowd/create.py
+++ b/bittensor_cli/src/commands/crowd/create.py
@@ -484,6 +484,8 @@ async def create_crowdloan(
                     }
                 )
             )
+        else:
+            console.print("[green]Announcement submitted[/green] — not executed yet.")
         return True, "Crowdloan creation announcement submitted."
 
     if json_output:
@@ -788,6 +790,8 @@ async def finalize_crowdloan(
                     }
                 )
             )
+        else:
+            console.print("[green]Announcement submitted[/green] — not executed yet.")
         return True, "Crowdloan finalization announcement submitted."
 
     if json_output:

--- a/bittensor_cli/src/commands/crowd/create.py
+++ b/bittensor_cli/src/commands/crowd/create.py
@@ -45,6 +45,7 @@ async def create_crowdloan(
     wait_for_inclusion: bool,
     wait_for_finalization: bool,
     prompt: bool,
+    announce_only: bool = False,
     decline: bool = False,
     quiet: bool = False,
     json_output: bool = False,
@@ -427,6 +428,12 @@ async def create_crowdloan(
             + (" (paid by signer account)" if proxy else ""),
         )
         console.print(table)
+        if announce_only:
+            console.print(
+                "[dim]Note: with --announce-only the call is not executed now. These "
+                "figures reflect the current chain state and may differ when the "
+                "announced call is executed.[/dim]"
+            )
 
         if not confirm_action(
             "Proceed with creating the crowdloan?", decline=decline, quiet=quiet
@@ -447,6 +454,7 @@ async def create_crowdloan(
         proxy=proxy,
         wait_for_inclusion=wait_for_inclusion,
         wait_for_finalization=wait_for_finalization,
+        announce_only=announce_only,
     )
 
     if not success:
@@ -462,6 +470,21 @@ async def create_crowdloan(
         else:
             print_error(f"{error_message or 'Failed to create crowdloan.'}")
         return False, error_message or "Failed to create crowdloan."
+
+    if announce_only:
+        if json_output:
+            announce_id = await extrinsic_receipt.get_extrinsic_identifier()
+            json_console.print(
+                json.dumps(
+                    {
+                        "success": True,
+                        "error": None,
+                        "announce_only": True,
+                        "extrinsic_identifier": announce_id,
+                    }
+                )
+            )
+        return True, "Crowdloan creation announcement submitted."
 
     if json_output:
         extrinsic_id = await extrinsic_receipt.get_extrinsic_identifier()
@@ -547,6 +570,7 @@ async def finalize_crowdloan(
     wait_for_inclusion: bool,
     wait_for_finalization: bool,
     prompt: bool,
+    announce_only: bool = False,
     decline: bool = False,
     quiet: bool = False,
     json_output: bool = False,
@@ -689,6 +713,12 @@ async def finalize_crowdloan(
         )
 
         console.print(table)
+        if announce_only:
+            console.print(
+                "[dim]Note: with --announce-only the call is not executed now. These "
+                "figures reflect the current chain state and may differ when the "
+                "announced call is executed.[/dim]"
+            )
 
         console.print(
             "\n[bold yellow]Important:[/bold yellow]\n"
@@ -726,6 +756,7 @@ async def finalize_crowdloan(
         wait_for_inclusion=wait_for_inclusion,
         wait_for_finalization=wait_for_finalization,
         proxy=proxy,
+        announce_only=announce_only,
     )
 
     if not success:
@@ -743,6 +774,21 @@ async def finalize_crowdloan(
                 f"[red]Failed to finalize: {error_message or 'Unknown error'}[/red]"
             )
         return False, error_message or "Failed to finalize crowdloan."
+
+    if announce_only:
+        if json_output:
+            announce_id = await extrinsic_receipt.get_extrinsic_identifier()
+            json_console.print(
+                json.dumps(
+                    {
+                        "success": True,
+                        "error": None,
+                        "announce_only": True,
+                        "extrinsic_identifier": announce_id,
+                    }
+                )
+            )
+        return True, "Crowdloan finalization announcement submitted."
 
     if json_output:
         extrinsic_id = await extrinsic_receipt.get_extrinsic_identifier()

--- a/bittensor_cli/src/commands/crowd/dissolve.py
+++ b/bittensor_cli/src/commands/crowd/dissolve.py
@@ -27,6 +27,7 @@ async def dissolve_crowdloan(
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
     prompt: bool = True,
+    announce_only: bool = False,
     decline: bool = False,
     quiet: bool = False,
     json_output: bool = False,
@@ -138,6 +139,12 @@ async def dissolve_crowdloan(
 
     console.print("\n[bold cyan]Crowdloan Dissolution Summary[/bold cyan]")
     console.print(summary)
+    if announce_only:
+        console.print(
+            "[dim]Note: with --announce-only the call is not executed now. These figures "
+            "reflect the current chain state and may differ when the announced call is "
+            "executed.[/dim]"
+        )
 
     if prompt and not confirm_action(
         f"\n[bold]Proceed with dissolving crowdloan #{crowdloan_id}?[/bold]",
@@ -183,6 +190,7 @@ async def dissolve_crowdloan(
             proxy=proxy,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
+            announce_only=announce_only,
         )
 
     if not success:
@@ -198,6 +206,21 @@ async def dissolve_crowdloan(
         else:
             print_error(f"[red]Failed to dissolve crowdloan.[/red]\n{error_message}")
         return False, error_message
+
+    if announce_only:
+        if json_output:
+            announce_id = await extrinsic_receipt.get_extrinsic_identifier()
+            json_console.print(
+                json.dumps(
+                    {
+                        "success": True,
+                        "error": None,
+                        "announce_only": True,
+                        "extrinsic_identifier": announce_id,
+                    }
+                )
+            )
+        return True, "Crowdloan dissolution announcement submitted."
 
     if json_output:
         extrinsic_id = await extrinsic_receipt.get_extrinsic_identifier()

--- a/bittensor_cli/src/commands/crowd/dissolve.py
+++ b/bittensor_cli/src/commands/crowd/dissolve.py
@@ -220,6 +220,8 @@ async def dissolve_crowdloan(
                     }
                 )
             )
+        else:
+            console.print("[green]Announcement submitted[/green] — not executed yet.")
         return True, "Crowdloan dissolution announcement submitted."
 
     if json_output:

--- a/bittensor_cli/src/commands/crowd/refund.py
+++ b/bittensor_cli/src/commands/crowd/refund.py
@@ -230,6 +230,8 @@ async def refund_crowdloan(
                     }
                 )
             )
+        else:
+            console.print("[green]Announcement submitted[/green] — not executed yet.")
         return True, "Crowdloan refund announcement submitted."
 
     if json_output:

--- a/bittensor_cli/src/commands/crowd/refund.py
+++ b/bittensor_cli/src/commands/crowd/refund.py
@@ -27,6 +27,7 @@ async def refund_crowdloan(
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
     prompt: bool = True,
+    announce_only: bool = False,
     decline: bool = False,
     quiet: bool = False,
     json_output: bool = False,
@@ -141,6 +142,12 @@ async def refund_crowdloan(
         )
 
     console.print(info_table)
+    if announce_only:
+        console.print(
+            "[dim]Note: with --announce-only the call is not executed now. These figures "
+            "reflect the current chain state and may differ when the announced call is "
+            "executed.[/dim]"
+        )
 
     if estimated_calls > 1:
         console.print(
@@ -193,6 +200,7 @@ async def refund_crowdloan(
             proxy=proxy,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
+            announce_only=announce_only,
         )
 
     if not success:
@@ -208,6 +216,21 @@ async def refund_crowdloan(
         else:
             print_error(f"[red]Failed to refund contributors.[/red]\n{error_message}")
         return False, error_message
+
+    if announce_only:
+        if json_output:
+            announce_id = await extrinsic_receipt.get_extrinsic_identifier()
+            json_console.print(
+                json.dumps(
+                    {
+                        "success": True,
+                        "error": None,
+                        "announce_only": True,
+                        "extrinsic_identifier": announce_id,
+                    }
+                )
+            )
+        return True, "Crowdloan refund announcement submitted."
 
     if json_output:
         extrinsic_id = await extrinsic_receipt.get_extrinsic_identifier()

--- a/bittensor_cli/src/commands/crowd/update.py
+++ b/bittensor_cli/src/commands/crowd/update.py
@@ -33,6 +33,7 @@ async def update_crowdloan(
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
     prompt: bool = True,
+    announce_only: bool = False,
     decline: bool = False,
     quiet: bool = False,
     json_output: bool = False,
@@ -333,6 +334,12 @@ async def update_crowdloan(
         table.add_row("Cap", str(crowdloan.cap), str(value))
 
     console.print(table)
+    if announce_only:
+        console.print(
+            "[dim]Note: with --announce-only the call is not executed now. These figures "
+            "reflect the current chain state and may differ when the announced call is "
+            "executed.[/dim]"
+        )
 
     if prompt and not confirm_action(
         f"\n[bold]Proceed with updating {update_type}?[/bold]",
@@ -380,6 +387,7 @@ async def update_crowdloan(
             proxy=proxy,
             wait_for_inclusion=wait_for_inclusion,
             wait_for_finalization=wait_for_finalization,
+            announce_only=announce_only,
         )
 
     if not success:
@@ -395,6 +403,21 @@ async def update_crowdloan(
         else:
             print_error(f"[red]Failed to update {update_type}.[/red]\n{error_message}")
         return False, error_message
+
+    if announce_only:
+        if json_output:
+            announce_id = await extrinsic_receipt.get_extrinsic_identifier()
+            json_console.print(
+                json.dumps(
+                    {
+                        "success": True,
+                        "error": None,
+                        "announce_only": True,
+                        "extrinsic_identifier": announce_id,
+                    }
+                )
+            )
+        return True, "Crowdloan update announcement submitted."
 
     if json_output:
         extrinsic_id = await extrinsic_receipt.get_extrinsic_identifier()

--- a/bittensor_cli/src/commands/crowd/update.py
+++ b/bittensor_cli/src/commands/crowd/update.py
@@ -417,6 +417,8 @@ async def update_crowdloan(
                     }
                 )
             )
+        else:
+            console.print("[green]Announcement submitted[/green] — not executed yet.")
         return True, "Crowdloan update announcement submitted."
 
     if json_output:

--- a/bittensor_cli/src/commands/liquidity/liquidity.py
+++ b/bittensor_cli/src/commands/liquidity/liquidity.py
@@ -323,6 +323,10 @@ async def add_liquidity(
                 console.print(
                     "[green]LiquidityPosition has been successfully added.[/green]"
                 )
+            else:
+                console.print(
+                    "[green]Announcement submitted[/green] — not executed yet."
+                )
         else:
             print_error(f"Error: {message}")
     return success, message
@@ -642,6 +646,11 @@ async def remove_liquidity(
                 await print_extrinsic_id(ext_receipt)
                 if not announce_only:
                     console.print(f"[green] Position {posid} has been removed.")
+                else:
+                    console.print(
+                        f"[green]Announcement submitted[/green] — position {posid} "
+                        f"not executed yet."
+                    )
             else:
                 print_error(f"Error removing {posid}: {msg}")
     else:
@@ -719,6 +728,10 @@ async def modify_liquidity(
             await print_extrinsic_id(ext_receipt)
             if not announce_only:
                 console.print(f"[green] Position {position_id} has been modified.")
+            else:
+                console.print(
+                    "[green]Announcement submitted[/green] — not executed yet."
+                )
         else:
             print_error(f"Error modifying {position_id}: {msg}")
     return success

--- a/bittensor_cli/src/commands/liquidity/liquidity.py
+++ b/bittensor_cli/src/commands/liquidity/liquidity.py
@@ -39,6 +39,7 @@ async def add_liquidity_extrinsic(
     price_high: Balance,
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
+    announce_only: bool = False,
 ) -> tuple[bool, str, Optional[AsyncExtrinsicReceipt]]:
     """
     Adds liquidity to the specified price range.
@@ -54,6 +55,8 @@ async def add_liquidity_extrinsic(
         price_high: The upper bound of the price tick range.
         wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
         wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+        announce_only: If set together with proxy, submits a `Proxy.announce` of the call hash to be
+            executed later instead of executing the call now. Defaults to False.
 
     Returns:
         tuple:
@@ -88,6 +91,7 @@ async def add_liquidity_extrinsic(
         proxy=proxy,
         wait_for_inclusion=wait_for_inclusion,
         wait_for_finalization=wait_for_finalization,
+        announce_only=announce_only,
     )
 
 
@@ -101,6 +105,7 @@ async def modify_liquidity_extrinsic(
     liquidity_delta: Balance,
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
+    announce_only: bool = False,
 ) -> tuple[bool, str, Optional[AsyncExtrinsicReceipt]]:
     """Modifies liquidity in liquidity position by adding or removing liquidity from it.
 
@@ -114,6 +119,8 @@ async def modify_liquidity_extrinsic(
         liquidity_delta: The amount of liquidity to be added or removed (add if positive or remove if negative).
         wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
         wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+        announce_only: If set together with proxy, submits a `Proxy.announce` of the call hash to be
+            executed later instead of executing the call now. Defaults to False.
 
     Returns:
         tuple:
@@ -144,6 +151,7 @@ async def modify_liquidity_extrinsic(
         proxy=proxy,
         wait_for_inclusion=wait_for_inclusion,
         wait_for_finalization=wait_for_finalization,
+        announce_only=announce_only,
     )
 
 
@@ -156,6 +164,7 @@ async def remove_liquidity_extrinsic(
     position_id: int,
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
+    announce_only: bool = False,
 ) -> tuple[bool, str, Optional[AsyncExtrinsicReceipt]]:
     """Remove liquidity and credit balances back to wallet's hotkey stake.
 
@@ -168,6 +177,8 @@ async def remove_liquidity_extrinsic(
         position_id: The id of the position record in the pool.
         wait_for_inclusion: Whether to wait for the extrinsic to be included in a block. Defaults to True.
         wait_for_finalization: Whether to wait for finalization of the extrinsic. Defaults to False.
+        announce_only: If set together with proxy, submits a `Proxy.announce` of the call hash to be
+            executed later instead of executing the call now. Defaults to False.
 
     Returns:
         tuple:
@@ -197,6 +208,7 @@ async def remove_liquidity_extrinsic(
         proxy=proxy,
         wait_for_inclusion=wait_for_inclusion,
         wait_for_finalization=wait_for_finalization,
+        announce_only=announce_only,
     )
 
 
@@ -254,6 +266,7 @@ async def add_liquidity(
     decline: bool,
     quiet: bool,
     json_output: bool,
+    announce_only: bool = False,
 ) -> tuple[bool, str]:
     """Add liquidity position to provided subnet."""
     # Check wallet access
@@ -288,6 +301,7 @@ async def add_liquidity(
         liquidity=liquidity,
         price_low=price_low,
         price_high=price_high,
+        announce_only=announce_only,
     )
     if success:
         await print_extrinsic_id(ext_receipt)
@@ -299,14 +313,16 @@ async def add_liquidity(
             data={
                 "success": success,
                 "message": message,
+                "announce_only": announce_only,
                 "extrinsic_identifier": ext_id,
             }
         )
     else:
         if success:
-            console.print(
-                "[green]LiquidityPosition has been successfully added.[/green]"
-            )
+            if not announce_only:
+                console.print(
+                    "[green]LiquidityPosition has been successfully added.[/green]"
+                )
         else:
             print_error(f"Error: {message}")
     return success, message
@@ -572,6 +588,7 @@ async def remove_liquidity(
     quiet: bool = False,
     all_liquidity_ids: Optional[bool] = None,
     json_output: bool = False,
+    announce_only: bool = False,
 ) -> None:
     """Remove liquidity position from provided subnet."""
     if not await subtensor.subnet_exists(netuid=netuid):
@@ -614,6 +631,7 @@ async def remove_liquidity(
                 proxy=proxy,
                 netuid=netuid,
                 position_id=pos_id,
+                announce_only=announce_only,
             )
             for pos_id in position_ids
         ]
@@ -622,7 +640,8 @@ async def remove_liquidity(
         for (success, msg, ext_receipt), posid in zip(results, position_ids):
             if success:
                 await print_extrinsic_id(ext_receipt)
-                console.print(f"[green] Position {posid} has been removed.")
+                if not announce_only:
+                    console.print(f"[green] Position {posid} has been removed.")
             else:
                 print_error(f"Error removing {posid}: {msg}")
     else:
@@ -631,6 +650,7 @@ async def remove_liquidity(
             json_table[posid] = {
                 "success": success,
                 "err_msg": msg,
+                "announce_only": announce_only,
                 "extrinsic_identifier": await ext_receipt.get_extrinsic_identifier(),
             }
         json_console.print_json(data=json_table)
@@ -649,6 +669,7 @@ async def modify_liquidity(
     decline: bool = False,
     quiet: bool = False,
     json_output: bool = False,
+    announce_only: bool = False,
 ) -> bool:
     """Modify liquidity position in provided subnet."""
     if not await subtensor.subnet_exists(netuid=netuid):
@@ -681,16 +702,23 @@ async def modify_liquidity(
         proxy=proxy,
         position_id=position_id,
         liquidity_delta=liquidity_delta,
+        announce_only=announce_only,
     )
     if json_output:
         ext_id = await ext_receipt.get_extrinsic_identifier() if success else None
         json_console.print_json(
-            data={"success": success, "err_msg": msg, "extrinsic_identifier": ext_id}
+            data={
+                "success": success,
+                "err_msg": msg,
+                "announce_only": announce_only,
+                "extrinsic_identifier": ext_id,
+            }
         )
     else:
         if success:
             await print_extrinsic_id(ext_receipt)
-            console.print(f"[green] Position {position_id} has been modified.")
+            if not announce_only:
+                console.print(f"[green] Position {position_id} has been modified.")
         else:
             print_error(f"Error modifying {position_id}: {msg}")
     return success

--- a/bittensor_cli/src/commands/stake/add.py
+++ b/bittensor_cli/src/commands/stake/add.py
@@ -53,6 +53,7 @@ async def stake_add(
     era: int,
     mev_protection: bool,
     proxy: Optional[str],
+    announce_only: bool = False,
 ):
     """
     Args:
@@ -150,6 +151,7 @@ async def stake_add(
             era={"period": era},
             proxy=proxy,
             mev_protection=mev_protection,
+            announce_only=announce_only,
         )
         if not success_:
             if "Custom error: 8" in err_msg:
@@ -181,6 +183,8 @@ async def stake_add(
                 # the rest of this checking is not necessary if using json_output
                 return True, "", response
             await print_extrinsic_id(response)
+            if announce_only:
+                return True, "", response
             block_hash = await subtensor.substrate.get_chain_head()
             new_balance, new_stake = await asyncio.gather(
                 subtensor.get_balance(coldkey_ss58, block_hash),
@@ -248,6 +252,7 @@ async def stake_add(
             era={"period": era},
             proxy=proxy,
             mev_protection=mev_protection,
+            announce_only=announce_only,
         )
         if not success_:
             err_msg = f"{failure_prelude} with error: {err_msg}"
@@ -271,6 +276,8 @@ async def stake_add(
                 # the rest of this is not necessary if using json_output
                 return True, "", response
             await print_extrinsic_id(response)
+            if announce_only:
+                return True, "", response
             new_block_hash = await subtensor.substrate.get_chain_head()
             new_balance, new_stake = await asyncio.gather(
                 subtensor.get_balance(
@@ -516,7 +523,7 @@ async def stake_add(
     table = _define_stake_table(wallet, subtensor, safe_staking, rate_tolerance)
     for row in rows:
         table.add_row(*row)
-    _print_table_and_slippage(table, max_slippage, safe_staking)
+    _print_table_and_slippage(table, max_slippage, safe_staking, announce_only)
 
     if prompt:
         if not confirm_action(
@@ -581,6 +588,7 @@ async def stake_add(
                 era={"period": era},
                 proxy=proxy,
                 mev_protection=mev_protection,
+                announce_only=announce_only,
                 block_hash=batch_block_hash,
             )
 
@@ -607,35 +615,36 @@ async def stake_add(
 
                 if not json_output:
                     await print_extrinsic_id(response)
-                    new_block_hash = await subtensor.substrate.get_chain_head()
-                    new_balance = await subtensor.get_balance(
-                        coldkey_ss58, block_hash=new_block_hash
-                    )
-                    print_success(
-                        f"[dark_sea_green3]Batch finalized. "
-                        f"Staked across {total_ops} operations.[/dark_sea_green3]"
-                    )
-                    console.print(
-                        f"Balance:\n  [blue]{current_balance}[/blue] :arrow_right: "
-                        f"[{COLOR_PALETTE['STAKE']['STAKE_AMOUNT']}]{new_balance}"
-                    )
-                    for ni, hk, am, curr, _ in operations:
-                        new_stake = await subtensor.get_stake(
-                            hotkey_ss58=hk,
-                            coldkey_ss58=coldkey_ss58,
-                            netuid=ni,
-                            block_hash=new_block_hash,
+                    if not announce_only:
+                        new_block_hash = await subtensor.substrate.get_chain_head()
+                        new_balance = await subtensor.get_balance(
+                            coldkey_ss58, block_hash=new_block_hash
+                        )
+                        print_success(
+                            f"[dark_sea_green3]Batch finalized. "
+                            f"Staked across {total_ops} operations.[/dark_sea_green3]"
                         )
                         console.print(
-                            f"Subnet: [{COLOR_PALETTE['GENERAL']['SUBHEADING']}]"
-                            f"{ni}[/{COLOR_PALETTE['GENERAL']['SUBHEADING']}] "
-                            f"Hotkey: [{COLOR_PALETTE['GENERAL']['HOTKEY']}]{hk}"
-                            f"[/{COLOR_PALETTE['GENERAL']['HOTKEY']}] "
-                            f"Stake:\n"
-                            f"  [blue]{curr}[/blue] "
-                            f":arrow_right: "
-                            f"[{COLOR_PALETTE['STAKE']['STAKE_AMOUNT']}]{new_stake}"
+                            f"Balance:\n  [blue]{current_balance}[/blue] :arrow_right: "
+                            f"[{COLOR_PALETTE['STAKE']['STAKE_AMOUNT']}]{new_balance}"
                         )
+                        for ni, hk, am, curr, _ in operations:
+                            new_stake = await subtensor.get_stake(
+                                hotkey_ss58=hk,
+                                coldkey_ss58=coldkey_ss58,
+                                netuid=ni,
+                                block_hash=new_block_hash,
+                            )
+                            console.print(
+                                f"Subnet: [{COLOR_PALETTE['GENERAL']['SUBHEADING']}]"
+                                f"{ni}[/{COLOR_PALETTE['GENERAL']['SUBHEADING']}] "
+                                f"Hotkey: [{COLOR_PALETTE['GENERAL']['HOTKEY']}]{hk}"
+                                f"[/{COLOR_PALETTE['GENERAL']['HOTKEY']}] "
+                                f"Stake:\n"
+                                f"  [blue]{curr}[/blue] "
+                                f":arrow_right: "
+                                f"[{COLOR_PALETTE['STAKE']['STAKE_AMOUNT']}]{new_stake}"
+                            )
             else:
                 print_error(
                     f":cross_mark: [red]Batch staking failed[/red]: {err_msg}",
@@ -852,14 +861,23 @@ def _define_stake_table(
     return table
 
 
-def _print_table_and_slippage(table: Table, max_slippage: float, safe_staking: bool):
+def _print_table_and_slippage(
+    table: Table, max_slippage: float, safe_staking: bool, announce_only: bool = False
+):
     """Prints the stake table, slippage warning, and table description.
 
     Args:
         table: The rich Table object to print
         max_slippage: The maximum slippage percentage across all operations
+        announce_only: whether this is an announce-only proxy call (adds a disclaimer)
     """
     console.print(table)
+    if announce_only:
+        console.print(
+            "[dim]Note: with --announce-only the call is not executed now. These figures "
+            "reflect the current chain state and may differ when the announced call is "
+            "executed.[/dim]"
+        )
 
     # Greater than 5%
     if max_slippage > 5:

--- a/bittensor_cli/src/commands/stake/add.py
+++ b/bittensor_cli/src/commands/stake/add.py
@@ -184,6 +184,9 @@ async def stake_add(
                 return True, "", response
             await print_extrinsic_id(response)
             if announce_only:
+                console.print(
+                    "[green]Announcement submitted[/green] — not executed yet."
+                )
                 return True, "", response
             block_hash = await subtensor.substrate.get_chain_head()
             new_balance, new_stake = await asyncio.gather(
@@ -277,6 +280,9 @@ async def stake_add(
                 return True, "", response
             await print_extrinsic_id(response)
             if announce_only:
+                console.print(
+                    "[green]Announcement submitted[/green] — not executed yet."
+                )
                 return True, "", response
             new_block_hash = await subtensor.substrate.get_chain_head()
             new_balance, new_stake = await asyncio.gather(
@@ -645,6 +651,11 @@ async def stake_add(
                                 f":arrow_right: "
                                 f"[{COLOR_PALETTE['STAKE']['STAKE_AMOUNT']}]{new_stake}"
                             )
+                    else:
+                        console.print(
+                            f"[green]Announcement submitted[/green] — batch of "
+                            f"{total_ops} operations, not executed yet."
+                        )
             else:
                 print_error(
                     f":cross_mark: [red]Batch staking failed[/red]: {err_msg}",

--- a/bittensor_cli/src/commands/stake/move.py
+++ b/bittensor_cli/src/commands/stake/move.py
@@ -800,6 +800,9 @@ async def move_stake(
                     return False, ""
             await print_extrinsic_id(response)
             if announce_only:
+                console.print(
+                    "[green]Announcement submitted[/green] — not executed yet."
+                )
                 return True, ext_id
             if not prompt:
                 print_success("Sent")
@@ -1189,6 +1192,9 @@ async def transfer_stake(
             await print_extrinsic_id(response)
             ext_id = await response.get_extrinsic_identifier()
             if announce_only:
+                console.print(
+                    "[green]Announcement submitted[/green] — not executed yet."
+                )
                 return True, ext_id
             if not prompt:
                 print_success("Sent")
@@ -1445,6 +1451,9 @@ async def swap_stake(
                     return False, ""
             await print_extrinsic_id(response)
             if announce_only:
+                console.print(
+                    "[green]Announcement submitted[/green] — not executed yet."
+                )
                 return True, ext_id
             if not prompt:
                 print_success("Sent")

--- a/bittensor_cli/src/commands/stake/move.py
+++ b/bittensor_cli/src/commands/stake/move.py
@@ -123,6 +123,7 @@ async def display_stake_movement_cross_subnets(
     rate_tolerance: Optional[float] = None,
     allow_partial_stake: bool = False,
     proxy: Optional[str] = None,
+    announce_only: bool = False,
 ) -> tuple[Balance, str]:
     """Calculate and display stake movement information.
 
@@ -294,6 +295,12 @@ async def display_stake_movement_cross_subnets(
     table.add_row(*row)
 
     console.print(table)
+    if announce_only:
+        console.print(
+            "[dim]Note: with --announce-only the call is not executed now. These figures "
+            "reflect the current chain state and may differ when the announced call is "
+            "executed.[/dim]"
+        )
 
     return received_amount, price_str
 
@@ -579,6 +586,7 @@ async def move_stake(
     quiet: bool = False,
     proxy: Optional[str] = None,
     mev_protection: bool = True,
+    announce_only: bool = False,
 ) -> tuple[bool, str]:
     coldkey_ss58 = proxy or wallet.coldkeypub.ss58_address
     if interactive_selection:
@@ -749,6 +757,7 @@ async def move_stake(
                 else sim_swap.tao_fee,
                 extrinsic_fee=extrinsic_fee,
                 proxy=proxy,
+                announce_only=announce_only,
             )
         except ValueError:
             return False, ""
@@ -772,6 +781,7 @@ async def move_stake(
             proxy=proxy,
             mev_protection=mev_protection,
             nonce=next_nonce,
+            announce_only=announce_only,
         )
 
         ext_id = await response.get_extrinsic_identifier() if response else ""
@@ -789,6 +799,8 @@ async def move_stake(
                     print_error(f"\nFailed: {mev_error}")
                     return False, ""
             await print_extrinsic_id(response)
+            if announce_only:
+                return True, ext_id
             if not prompt:
                 print_success("Sent")
                 return True, ext_id
@@ -925,6 +937,7 @@ async def transfer_stake(
     quiet: bool = False,
     proxy: Optional[str] = None,
     mev_protection: bool = True,
+    announce_only: bool = False,
 ) -> tuple[bool, str]:
     """Transfers stake from one network to another.
 
@@ -1135,6 +1148,7 @@ async def transfer_stake(
                 else sim_swap.tao_fee,
                 extrinsic_fee=extrinsic_fee,
                 proxy=proxy,
+                announce_only=announce_only,
             )
         except ValueError:
             return False, ""
@@ -1156,6 +1170,7 @@ async def transfer_stake(
             proxy=proxy,
             mev_protection=mev_protection,
             nonce=next_nonce,
+            announce_only=announce_only,
         )
 
         if success_:
@@ -1173,6 +1188,8 @@ async def transfer_stake(
                     return False, ""
             await print_extrinsic_id(response)
             ext_id = await response.get_extrinsic_identifier()
+            if announce_only:
+                return True, ext_id
             if not prompt:
                 print_success("Sent")
                 return True, ext_id
@@ -1225,6 +1242,7 @@ async def swap_stake(
     wait_for_inclusion: bool = True,
     wait_for_finalization: bool = False,
     mev_protection: bool = True,
+    announce_only: bool = False,
 ) -> tuple[bool, str]:
     """Swaps stake between subnets while keeping the same coldkey-hotkey pair ownership.
 
@@ -1380,6 +1398,7 @@ async def swap_stake(
                 rate_tolerance=rate_tolerance,
                 allow_partial_stake=allow_partial_stake,
                 proxy=proxy,
+                announce_only=announce_only,
             )
         except ValueError:
             return False, ""
@@ -1406,6 +1425,7 @@ async def swap_stake(
             wait_for_inclusion=wait_for_inclusion,
             mev_protection=mev_protection,
             nonce=next_nonce,
+            announce_only=announce_only,
         )
 
         ext_id = await response.get_extrinsic_identifier()
@@ -1424,6 +1444,8 @@ async def swap_stake(
                     print_error(f"\nFailed: {mev_error}")
                     return False, ""
             await print_extrinsic_id(response)
+            if announce_only:
+                return True, ext_id
             if not prompt:
                 print_success("Sent")
                 return True, await response.get_extrinsic_identifier()

--- a/bittensor_cli/src/commands/stake/remove.py
+++ b/bittensor_cli/src/commands/stake/remove.py
@@ -57,6 +57,7 @@ async def unstake(
     era: int,
     proxy: Optional[str],
     mev_protection: bool,
+    announce_only: bool = False,
 ):
     """Unstake from hotkey(s)."""
     coldkey_ss58 = proxy or wallet.coldkeypub.ss58_address
@@ -412,7 +413,7 @@ async def unstake(
     for row in table_rows:
         table.add_row(*row)
 
-    _print_table_and_slippage(table, max_float_slippage, safe_staking)
+    _print_table_and_slippage(table, max_float_slippage, safe_staking, announce_only)
     if prompt:
         if not confirm_action(
             "Would you like to continue?", decline=decline, quiet=quiet
@@ -475,6 +476,7 @@ async def unstake(
                 era={"period": era},
                 proxy=proxy,
                 mev_protection=mev_protection,
+                announce_only=announce_only,
                 block_hash=batch_block_hash,
             )
 
@@ -509,32 +511,33 @@ async def unstake(
             if success:
                 if not json_output:
                     await print_extrinsic_id(response)
-                    new_block_hash = await subtensor.substrate.get_chain_head()
-                    new_balance = await subtensor.get_balance(
-                        coldkey_ss58, block_hash=new_block_hash
-                    )
-                    print_success(
-                        f"Batch finalized. Unstaked across {total_ops} operations."
-                    )
-                    console.print(
-                        f"Balance:\n  [blue]{current_balance}[/blue] :arrow_right: "
-                        f"[{COLOR_PALETTE.S.AMOUNT}]{new_balance}"
-                    )
-                    for op in unstake_operations:
-                        new_stake = await subtensor.get_stake(
-                            hotkey_ss58=op["hotkey_ss58"],
-                            coldkey_ss58=coldkey_ss58,
-                            netuid=op["netuid"],
-                            block_hash=new_block_hash,
+                    if not announce_only:
+                        new_block_hash = await subtensor.substrate.get_chain_head()
+                        new_balance = await subtensor.get_balance(
+                            coldkey_ss58, block_hash=new_block_hash
+                        )
+                        print_success(
+                            f"Batch finalized. Unstaked across {total_ops} operations."
                         )
                         console.print(
-                            f"Subnet: [{COLOR_PALETTE.G.SUBHEAD}]{op['netuid']}"
-                            f"[/{COLOR_PALETTE.G.SUBHEAD}] "
-                            f"Hotkey: [{COLOR_PALETTE.G.HK}]{op['hotkey_ss58']}"
-                            f"[/{COLOR_PALETTE.G.HK}] "
-                            f"Stake:\n  [blue]{op['current_stake_balance']}[/blue] "
-                            f":arrow_right: [{COLOR_PALETTE.S.AMOUNT}]{new_stake}"
+                            f"Balance:\n  [blue]{current_balance}[/blue] :arrow_right: "
+                            f"[{COLOR_PALETTE.S.AMOUNT}]{new_balance}"
                         )
+                        for op in unstake_operations:
+                            new_stake = await subtensor.get_stake(
+                                hotkey_ss58=op["hotkey_ss58"],
+                                coldkey_ss58=coldkey_ss58,
+                                netuid=op["netuid"],
+                                block_hash=new_block_hash,
+                            )
+                            console.print(
+                                f"Subnet: [{COLOR_PALETTE.G.SUBHEAD}]{op['netuid']}"
+                                f"[/{COLOR_PALETTE.G.SUBHEAD}] "
+                                f"Hotkey: [{COLOR_PALETTE.G.HK}]{op['hotkey_ss58']}"
+                                f"[/{COLOR_PALETTE.G.HK}] "
+                                f"Stake:\n  [blue]{op['current_stake_balance']}[/blue] "
+                                f":arrow_right: [{COLOR_PALETTE.S.AMOUNT}]{new_stake}"
+                            )
             else:
                 print_error(
                     f":cross_mark: [red]Batch unstaking failed[/red]: {err_msg}",
@@ -556,6 +559,7 @@ async def unstake(
                     "era": era,
                     "proxy": proxy,
                     "mev_protection": mev_protection,
+                    "announce_only": announce_only,
                 }
 
                 if safe_staking and op["netuid"] != 0:
@@ -581,9 +585,10 @@ async def unstake(
                     }
                 )
 
-    console.print(
-        f"[{COLOR_PALETTE['STAKE']['STAKE_AMOUNT']}]Unstaking operations completed."
-    )
+    if not announce_only:
+        console.print(
+            f"[{COLOR_PALETTE['STAKE']['STAKE_AMOUNT']}]Unstaking operations completed."
+        )
     if json_output:
         json_console.print_json(data=successes)
     return True
@@ -604,6 +609,7 @@ async def unstake_all(
     json_output: bool = False,
     proxy: Optional[str] = None,
     mev_protection: bool = True,
+    announce_only: bool = False,
 ) -> None:
     """Unstakes all stakes from all hotkeys in all subnets."""
     include_hotkeys = include_hotkeys or []
@@ -787,6 +793,12 @@ async def unstake_all(
     console.print(
         f"Total expected return: [{COLOR_PALETTE['STAKE']['STAKE_AMOUNT']}]{total_received_value}"
     )
+    if announce_only:
+        console.print(
+            "[dim]Note: with --announce-only the call is not executed now. These figures "
+            "reflect the current chain state and may differ when the announced call is "
+            "executed.[/dim]"
+        )
 
     if prompt and not confirm_action(
         "\nDo you want to proceed with unstaking everything?",
@@ -825,6 +837,7 @@ async def unstake_all(
                 era={"period": era},
                 proxy=proxy,
                 mev_protection=mev_protection,
+                announce_only=announce_only,
                 block_hash=batch_block_hash,
             )
 
@@ -853,19 +866,20 @@ async def unstake_all(
 
             if success:
                 await print_extrinsic_id(response)
-                msg_modifier = "Alpha " if unstake_all_alpha else ""
-                new_block_hash = await subtensor.substrate.get_chain_head()
-                new_balance = await subtensor.get_balance(
-                    coldkey_ss58, block_hash=new_block_hash
-                )
-                print_success(
-                    f"Batch finalized. Unstaked all {msg_modifier}stakes "
-                    f"from {len(hotkey_ss58s)} hotkeys."
-                )
-                console.print(
-                    f"Balance:\n  [blue]{current_wallet_balance}[/blue] "
-                    f":arrow_right: [{COLOR_PALETTE.S.AMOUNT}]{new_balance}"
-                )
+                if not announce_only:
+                    msg_modifier = "Alpha " if unstake_all_alpha else ""
+                    new_block_hash = await subtensor.substrate.get_chain_head()
+                    new_balance = await subtensor.get_balance(
+                        coldkey_ss58, block_hash=new_block_hash
+                    )
+                    print_success(
+                        f"Batch finalized. Unstaked all {msg_modifier}stakes "
+                        f"from {len(hotkey_ss58s)} hotkeys."
+                    )
+                    console.print(
+                        f"Balance:\n  [blue]{current_wallet_balance}[/blue] "
+                        f":arrow_right: [{COLOR_PALETTE.S.AMOUNT}]{new_balance}"
+                    )
             else:
                 print_error(
                     f":cross_mark: [red]Batch unstake-all failed[/red]: {err_msg}",
@@ -885,6 +899,7 @@ async def unstake_all(
                     era=era,
                     proxy=proxy,
                     mev_protection=mev_protection,
+                    announce_only=announce_only,
                 )
                 ext_id = (
                     await ext_receipt.get_extrinsic_identifier() if success else None
@@ -909,6 +924,7 @@ async def _unstake_extrinsic(
     era: int = 3,
     proxy: Optional[str] = None,
     mev_protection: bool = True,
+    announce_only: bool = False,
 ) -> tuple[bool, Optional[AsyncExtrinsicReceipt]]:
     """Execute a standard unstake extrinsic.
 
@@ -951,13 +967,13 @@ async def _unstake_extrinsic(
     )
 
     success, err_msg, response = await subtensor.sign_and_send_extrinsic(
-        # TODO I think this should handle announce-only
         call=call,
         wallet=wallet,
         era={"period": era},
         proxy=proxy,
         mev_protection=mev_protection,
         nonce=next_nonce,
+        announce_only=announce_only,
     )
     if success:
         if mev_protection:
@@ -973,6 +989,8 @@ async def _unstake_extrinsic(
                 print_error(f"\nFailed: {mev_error}")
                 return False, None
         await print_extrinsic_id(response)
+        if announce_only:
+            return True, response
         block_hash = await subtensor.substrate.get_chain_head()
         new_balance, new_stake = await asyncio.gather(
             subtensor.get_balance(coldkey_ss58, block_hash),
@@ -1010,6 +1028,7 @@ async def _safe_unstake_extrinsic(
     era: int = 3,
     proxy: Optional[str] = None,
     mev_protection: bool = True,
+    announce_only: bool = False,
 ) -> tuple[bool, Optional[AsyncExtrinsicReceipt]]:
     """Execute a safe unstake extrinsic with price limit.
 
@@ -1068,6 +1087,7 @@ async def _safe_unstake_extrinsic(
         era={"period": era},
         proxy=proxy,
         mev_protection=mev_protection,
+        announce_only=announce_only,
     )
     if success:
         if mev_protection:
@@ -1083,6 +1103,8 @@ async def _safe_unstake_extrinsic(
                 print_error(f"\nFailed: {mev_error}")
                 return False, None
         await print_extrinsic_id(response)
+        if announce_only:
+            return True, response
         block_hash = await subtensor.substrate.get_chain_head()
         new_balance, new_stake = await asyncio.gather(
             subtensor.get_balance(coldkey_ss58, block_hash),
@@ -1135,6 +1157,7 @@ async def _unstake_all_extrinsic(
     era: int = 3,
     proxy: Optional[str] = None,
     mev_protection: bool = True,
+    announce_only: bool = False,
 ) -> tuple[bool, Optional[AsyncExtrinsicReceipt]]:
     """Execute an unstake all extrinsic.
 
@@ -1192,6 +1215,7 @@ async def _unstake_all_extrinsic(
             nonce=next_nonce,
             proxy=proxy,
             mev_protection=mev_protection,
+            announce_only=announce_only,
         )
 
         if not success_:
@@ -1213,6 +1237,9 @@ async def _unstake_all_extrinsic(
                 return False, None
 
         await print_extrinsic_id(response)
+
+        if announce_only:
+            return True, response
 
         # Fetch latest balance and stake
         block_hash = await subtensor.substrate.get_chain_head()
@@ -1720,14 +1747,22 @@ def _print_table_and_slippage(
     table: Table,
     max_float_slippage: float,
     safe_staking: bool,
+    announce_only: bool = False,
 ) -> None:
     """Print the unstake summary table and additional information.
 
     Args:
         table: The Rich table containing unstake details
         max_float_slippage: Maximum slippage percentage across all operations
+        announce_only: whether this is an announce-only proxy call (adds a disclaimer)
     """
     console.print(table)
+    if announce_only:
+        console.print(
+            "[dim]Note: with --announce-only the call is not executed now. These figures "
+            "reflect the current chain state and may differ when the announced call is "
+            "executed.[/dim]"
+        )
 
     if max_float_slippage > 5:
         console.print(

--- a/bittensor_cli/src/commands/stake/remove.py
+++ b/bittensor_cli/src/commands/stake/remove.py
@@ -538,6 +538,11 @@ async def unstake(
                                 f"Stake:\n  [blue]{op['current_stake_balance']}[/blue] "
                                 f":arrow_right: [{COLOR_PALETTE.S.AMOUNT}]{new_stake}"
                             )
+                    else:
+                        console.print(
+                            f"[green]Announcement submitted[/green] — batch of "
+                            f"{total_ops} operations, not executed yet."
+                        )
             else:
                 print_error(
                     f":cross_mark: [red]Batch unstaking failed[/red]: {err_msg}",
@@ -880,6 +885,11 @@ async def unstake_all(
                         f"Balance:\n  [blue]{current_wallet_balance}[/blue] "
                         f":arrow_right: [{COLOR_PALETTE.S.AMOUNT}]{new_balance}"
                     )
+                else:
+                    console.print(
+                        f"[green]Announcement submitted[/green] — batch of "
+                        f"{len(hotkey_ss58s)} hotkeys, not executed yet."
+                    )
             else:
                 print_error(
                     f":cross_mark: [red]Batch unstake-all failed[/red]: {err_msg}",
@@ -990,6 +1000,7 @@ async def _unstake_extrinsic(
                 return False, None
         await print_extrinsic_id(response)
         if announce_only:
+            console.print("[green]Announcement submitted[/green] — not executed yet.")
             return True, response
         block_hash = await subtensor.substrate.get_chain_head()
         new_balance, new_stake = await asyncio.gather(
@@ -1104,6 +1115,7 @@ async def _safe_unstake_extrinsic(
                 return False, None
         await print_extrinsic_id(response)
         if announce_only:
+            console.print("[green]Announcement submitted[/green] — not executed yet.")
             return True, response
         block_hash = await subtensor.substrate.get_chain_head()
         new_balance, new_stake = await asyncio.gather(
@@ -1239,6 +1251,7 @@ async def _unstake_all_extrinsic(
         await print_extrinsic_id(response)
 
         if announce_only:
+            console.print("[green]Announcement submitted[/green] — not executed yet.")
             return True, response
 
         # Fetch latest balance and stake

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import pytest
 import typer
 from async_substrate_interface import AsyncSubstrateInterface
@@ -401,6 +403,7 @@ def test_stake_add_calls_proxy_validation():
         mock_wallet_ask.return_value = Mock()
 
         cli_manager.stake_add(
+            announce_only=False,
             stake_all=False,
             amount=10.0,
             include_hotkeys="",
@@ -445,6 +448,7 @@ def test_stake_remove_calls_proxy_validation():
         mock_wallet_ask.return_value = Mock()
 
         cli_manager.stake_remove(
+            announce_only=False,
             network=None,
             wallet_name="test_wallet",
             wallet_path="/tmp/test",
@@ -568,6 +572,7 @@ def test_stake_move_calls_proxy_validation():
         mock_wallet_ask.return_value = mock_wallet
 
         cli_manager.stake_move(
+            announce_only=False,
             network=None,
             wallet_name="test_wallet",
             wallet_path="/tmp/test",
@@ -610,6 +615,7 @@ def test_stake_transfer_calls_proxy_validation():
         mock_wallet_ask.return_value = mock_wallet
 
         cli_manager.stake_transfer(
+            announce_only=False,
             network=None,
             wallet_name="test_wallet",
             wallet_path="/tmp/test",
@@ -629,6 +635,87 @@ def test_stake_transfer_calls_proxy_validation():
 
         # Assert that proxy validation was called
         mock_proxy_validation.assert_called_once_with(valid_proxy, False)
+
+
+def test_stake_add_threads_announce_only():
+    """stake_add with announce_only=True threads it into validation and downstream."""
+    cli_manager = CLIManager()
+    valid_proxy = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+
+    with (
+        patch.object(cli_manager, "verbosity_handler"),
+        patch.object(cli_manager, "wallet_ask") as mock_wallet_ask,
+        patch.object(cli_manager, "initialize_chain"),
+        patch.object(cli_manager, "_run_command"),
+        patch.object(cli_manager, "ask_safe_staking", return_value=False),
+        patch("bittensor_cli.cli.add_stake") as mock_add_stake,
+        patch.object(
+            cli_manager, "is_valid_proxy_name_or_ss58", return_value=valid_proxy
+        ) as mock_proxy_validation,
+    ):
+        mock_wallet_ask.return_value = Mock()
+
+        cli_manager.stake_add(
+            announce_only=True,
+            mev_protection=False,
+            stake_all=False,
+            amount=10.0,
+            include_hotkeys="",
+            exclude_hotkeys="",
+            all_hotkeys=False,
+            netuids="1",
+            all_netuids=False,
+            wallet_name="test_wallet",
+            wallet_path="/tmp/test",
+            wallet_hotkey="test_hotkey",
+            proxy=valid_proxy,
+            network=None,
+            rate_tolerance=None,
+            safe_staking=False,
+            allow_partial_stake=None,
+            period=100,
+            prompt=False,
+            quiet=True,
+            verbose=False,
+            json_output=False,
+        )
+
+        mock_proxy_validation.assert_called_once_with(valid_proxy, True)
+        _, kwargs = mock_add_stake.stake_add.call_args
+        assert kwargs["announce_only"] is True
+
+
+def test_resolve_mev_for_announce_no_conflict_returns_mev():
+    """When there is no announce/mev conflict, mev_protection is returned unchanged."""
+    cli_manager = CLIManager()
+    # announce_only False -> mev unchanged either way
+    assert cli_manager._resolve_mev_for_announce(None, False, True) is True
+    assert cli_manager._resolve_mev_for_announce(None, False, False) is False
+    # announce_only True but mev already off -> unchanged
+    assert cli_manager._resolve_mev_for_announce(None, True, False) is False
+
+
+def test_resolve_mev_for_announce_default_mev_disabled_silently():
+    """announce_only with default-on mev (no ctx) disables mev rather than erroring."""
+    cli_manager = CLIManager()
+    assert cli_manager._resolve_mev_for_announce(None, True, True) is False
+
+
+def test_resolve_mev_for_announce_explicit_mev_raises():
+    """Explicitly passing --mev-protection with --announce-only is a hard error."""
+    cli_manager = CLIManager()
+    ctx = Mock()
+    ctx.get_parameter_source.return_value = SimpleNamespace(name="COMMANDLINE")
+    with pytest.raises(typer.BadParameter):
+        cli_manager._resolve_mev_for_announce(ctx, True, True)
+
+
+def test_resolve_mev_for_announce_default_source_disabled():
+    """Default-sourced mev with --announce-only is silently disabled."""
+    cli_manager = CLIManager()
+    ctx = Mock()
+    ctx.get_parameter_source.return_value = SimpleNamespace(name="DEFAULT")
+    assert cli_manager._resolve_mev_for_announce(ctx, True, True) is False
 
 
 def test_liquidity_add_calls_proxy_validation():

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -991,6 +991,144 @@ def test_crowd_contribute_threads_announce_only():
         assert kwargs["announce_only"] is True
 
 
+@pytest.mark.asyncio
+async def test_liquidity_add_prints_announcement_message():
+    """Under --announce-only, add_liquidity prints 'Announcement submitted' and
+    not the misleading completion message."""
+    from bittensor_cli.src.commands.liquidity import liquidity as liq
+    from bittensor_cli.src.bittensor.utils import console as bt_console
+    from bittensor_cli.src.bittensor.balances import Balance
+
+    receipt = MagicMock()
+    receipt.get_extrinsic_identifier = AsyncMock(return_value="0xabc")
+    mock_subtensor = MagicMock()
+    mock_subtensor.subnet_exists = AsyncMock(return_value=True)
+
+    with (
+        patch.object(
+            liq, "unlock_key", return_value=MagicMock(success=True, message="")
+        ),
+        patch.object(
+            liq,
+            "add_liquidity_extrinsic",
+            AsyncMock(return_value=(True, "ok", receipt)),
+        ),
+        patch.object(liq, "print_extrinsic_id", AsyncMock()),
+    ):
+        with bt_console.capture() as cap:
+            await liq.add_liquidity(
+                subtensor=mock_subtensor,
+                wallet=MagicMock(),
+                hotkey_ss58="hk",
+                netuid=1,
+                proxy="5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+                liquidity=Balance.from_tao(1),
+                price_low=Balance.from_tao(0.1),
+                price_high=Balance.from_tao(0.2),
+                prompt=False,
+                decline=False,
+                quiet=True,
+                json_output=False,
+                announce_only=True,
+            )
+        out = cap.get()
+
+    assert "Announcement submitted" in out
+    assert "successfully added" not in out
+
+
+@pytest.mark.asyncio
+async def test_unstake_extrinsic_prints_announcement_message():
+    """Under --announce-only, _unstake_extrinsic prints 'Announcement submitted'
+    and not 'Finalized'."""
+    from bittensor_cli.src.commands.stake import remove as rm
+    from bittensor_cli.src.bittensor.utils import console as bt_console
+    from bittensor_cli.src.bittensor.balances import Balance
+
+    receipt = MagicMock()
+    receipt.get_extrinsic_identifier = AsyncMock(return_value="0xabc")
+    mock_subtensor = MagicMock()
+    mock_subtensor.get_balance = AsyncMock(return_value=Balance.from_tao(10))
+    mock_subtensor.substrate.get_account_next_index = AsyncMock(return_value=0)
+    mock_subtensor.substrate.compose_call = AsyncMock(return_value=MagicMock())
+    mock_subtensor.sign_and_send_extrinsic = AsyncMock(return_value=(True, "", receipt))
+
+    with patch.object(rm, "print_extrinsic_id", AsyncMock()):
+        with bt_console.capture() as cap:
+            ok, _ = await rm._unstake_extrinsic(
+                wallet=MagicMock(coldkeypub=MagicMock(ss58_address="5Fsigner")),
+                subtensor=mock_subtensor,
+                netuid=1,
+                amount=Balance.from_tao(1),
+                current_stake=Balance.from_tao(5),
+                hotkey_ss58="hk",
+                status=None,
+                era=3,
+                proxy="5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty",
+                mev_protection=False,
+                announce_only=True,
+            )
+        out = cap.get()
+
+    assert ok is True
+    assert "Announcement submitted" in out
+    assert "Finalized" not in out
+
+
+@pytest.mark.asyncio
+async def test_dissolve_crowdloan_prints_announcement_message():
+    """Under --announce-only, dissolve_crowdloan prints 'Announcement submitted'
+    and not 'dissolved successfully'."""
+    from bittensor_cli.src.commands.crowd import dissolve as dsv
+    from bittensor_cli.src.bittensor.utils import console as bt_console
+    from bittensor_cli.src.bittensor.balances import Balance
+
+    proxy = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+    raised = Balance.from_tao(5)
+    crowdloan = MagicMock()
+    crowdloan.finalized = False
+    crowdloan.creator = proxy
+    crowdloan.raised = raised
+    crowdloan.contributors_count = 1
+    crowdloan.end = 1000
+
+    receipt = MagicMock()
+    receipt.get_extrinsic_identifier = AsyncMock(return_value="0xabc")
+    mock_subtensor = MagicMock()
+    mock_subtensor.get_single_crowdloan = AsyncMock(return_value=crowdloan)
+    mock_subtensor.substrate.get_block_number = AsyncMock(return_value=500)
+    mock_subtensor.get_crowdloan_contribution = AsyncMock(return_value=raised)
+    mock_subtensor.substrate.compose_call = AsyncMock(return_value=MagicMock())
+    mock_subtensor.sign_and_send_extrinsic = AsyncMock(return_value=(True, "", receipt))
+
+    with (
+        patch.object(dsv, "show_crowdloan_details", AsyncMock()),
+        patch.object(
+            dsv, "unlock_key", return_value=MagicMock(success=True, message="")
+        ),
+        patch.object(dsv, "print_extrinsic_id", AsyncMock()),
+    ):
+        with bt_console.capture() as cap:
+            ok, _ = await dsv.dissolve_crowdloan(
+                subtensor=mock_subtensor,
+                wallet=MagicMock(coldkeypub=MagicMock(ss58_address="5Fother")),
+                proxy=proxy,
+                crowdloan_id=1,
+                wait_for_inclusion=True,
+                wait_for_finalization=False,
+                prompt=False,
+                announce_only=True,
+                decline=False,
+                quiet=True,
+                json_output=False,
+            )
+        out = cap.get()
+
+    assert ok is True
+    assert "Announcement submitted" in out
+    assert "dissolved successfully" not in out
+
+
 # ============================================================================
 # Tests for root weights difference display
 # ============================================================================

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -631,6 +631,164 @@ def test_stake_transfer_calls_proxy_validation():
         mock_proxy_validation.assert_called_once_with(valid_proxy, False)
 
 
+def test_liquidity_add_calls_proxy_validation():
+    """liquidity_add forwards announce_only=False to proxy validation and downstream."""
+    cli_manager = CLIManager()
+    valid_proxy = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+
+    with (
+        patch.object(cli_manager, "verbosity_handler"),
+        patch.object(cli_manager, "wallet_ask") as mock_wallet_ask,
+        patch.object(cli_manager, "initialize_chain"),
+        patch.object(cli_manager, "_run_command"),
+        patch("bittensor_cli.cli.liquidity") as mock_liquidity,
+        patch.object(
+            cli_manager, "is_valid_proxy_name_or_ss58", return_value=valid_proxy
+        ) as mock_proxy_validation,
+    ):
+        mock_wallet_ask.return_value = (Mock(), "hotkey_ss58")
+
+        cli_manager.liquidity_add(
+            network=None,
+            wallet_name="test_wallet",
+            wallet_path="/tmp/test",
+            wallet_hotkey="test_hotkey",
+            netuid=1,
+            proxy=valid_proxy,
+            announce_only=False,
+            liquidity_=10.0,
+            price_low=0.1,
+            price_high=0.2,
+            prompt=False,
+            decline=False,
+            quiet=True,
+            verbose=False,
+            json_output=False,
+        )
+
+        mock_proxy_validation.assert_called_once_with(valid_proxy, False)
+        _, kwargs = mock_liquidity.add_liquidity.call_args
+        assert kwargs["announce_only"] is False
+
+
+def test_liquidity_add_threads_announce_only():
+    """liquidity_add with announce_only=True threads it into validation and downstream."""
+    cli_manager = CLIManager()
+    valid_proxy = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+
+    with (
+        patch.object(cli_manager, "verbosity_handler"),
+        patch.object(cli_manager, "wallet_ask") as mock_wallet_ask,
+        patch.object(cli_manager, "initialize_chain"),
+        patch.object(cli_manager, "_run_command"),
+        patch("bittensor_cli.cli.liquidity") as mock_liquidity,
+        patch.object(
+            cli_manager, "is_valid_proxy_name_or_ss58", return_value=valid_proxy
+        ) as mock_proxy_validation,
+    ):
+        mock_wallet_ask.return_value = (Mock(), "hotkey_ss58")
+
+        cli_manager.liquidity_add(
+            network=None,
+            wallet_name="test_wallet",
+            wallet_path="/tmp/test",
+            wallet_hotkey="test_hotkey",
+            netuid=1,
+            proxy=valid_proxy,
+            announce_only=True,
+            liquidity_=10.0,
+            price_low=0.1,
+            price_high=0.2,
+            prompt=False,
+            decline=False,
+            quiet=True,
+            verbose=False,
+            json_output=False,
+        )
+
+        mock_proxy_validation.assert_called_once_with(valid_proxy, True)
+        _, kwargs = mock_liquidity.add_liquidity.call_args
+        assert kwargs["announce_only"] is True
+
+
+def test_liquidity_remove_threads_announce_only():
+    """liquidity_remove with announce_only=True threads it into validation and downstream."""
+    cli_manager = CLIManager()
+    valid_proxy = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+
+    with (
+        patch.object(cli_manager, "verbosity_handler"),
+        patch.object(cli_manager, "wallet_ask") as mock_wallet_ask,
+        patch.object(cli_manager, "initialize_chain"),
+        patch.object(cli_manager, "_run_command"),
+        patch("bittensor_cli.cli.liquidity") as mock_liquidity,
+        patch.object(
+            cli_manager, "is_valid_proxy_name_or_ss58", return_value=valid_proxy
+        ) as mock_proxy_validation,
+    ):
+        mock_wallet_ask.return_value = (Mock(), "hotkey_ss58")
+
+        cli_manager.liquidity_remove(
+            network=None,
+            wallet_name="test_wallet",
+            wallet_path="/tmp/test",
+            wallet_hotkey="test_hotkey",
+            netuid=1,
+            proxy=valid_proxy,
+            announce_only=True,
+            position_id=1,
+            all_liquidity_ids=False,
+            prompt=False,
+            decline=False,
+            quiet=True,
+            verbose=False,
+            json_output=False,
+        )
+
+        mock_proxy_validation.assert_called_once_with(valid_proxy, True)
+        _, kwargs = mock_liquidity.remove_liquidity.call_args
+        assert kwargs["announce_only"] is True
+
+
+def test_liquidity_modify_threads_announce_only():
+    """liquidity_modify with announce_only=True threads it into validation and downstream."""
+    cli_manager = CLIManager()
+    valid_proxy = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+
+    with (
+        patch.object(cli_manager, "verbosity_handler"),
+        patch.object(cli_manager, "wallet_ask") as mock_wallet_ask,
+        patch.object(cli_manager, "initialize_chain"),
+        patch.object(cli_manager, "_run_command"),
+        patch("bittensor_cli.cli.liquidity") as mock_liquidity,
+        patch.object(
+            cli_manager, "is_valid_proxy_name_or_ss58", return_value=valid_proxy
+        ) as mock_proxy_validation,
+    ):
+        mock_wallet_ask.return_value = (Mock(), "hotkey_ss58")
+
+        cli_manager.liquidity_modify(
+            network=None,
+            wallet_name="test_wallet",
+            wallet_path="/tmp/test",
+            wallet_hotkey="test_hotkey",
+            netuid=1,
+            proxy=valid_proxy,
+            announce_only=True,
+            position_id=1,
+            liquidity_delta=5.0,
+            prompt=False,
+            decline=False,
+            quiet=True,
+            verbose=False,
+            json_output=False,
+        )
+
+        mock_proxy_validation.assert_called_once_with(valid_proxy, True)
+        _, kwargs = mock_liquidity.modify_liquidity.call_args
+        assert kwargs["announce_only"] is True
+
+
 # ============================================================================
 # Tests for root weights difference display
 # ============================================================================

--- a/tests/unit_tests/test_cli.py
+++ b/tests/unit_tests/test_cli.py
@@ -876,6 +876,121 @@ def test_liquidity_modify_threads_announce_only():
         assert kwargs["announce_only"] is True
 
 
+def test_crowd_dissolve_calls_proxy_validation():
+    """crowd_dissolve forwards announce_only=False to validation and downstream."""
+    cli_manager = CLIManager()
+    valid_proxy = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+
+    with (
+        patch.object(cli_manager, "verbosity_handler"),
+        patch.object(cli_manager, "wallet_ask") as mock_wallet_ask,
+        patch.object(cli_manager, "initialize_chain"),
+        patch.object(cli_manager, "_run_command"),
+        patch("bittensor_cli.cli.crowd_dissolve") as mock_dissolve,
+        patch.object(
+            cli_manager, "is_valid_proxy_name_or_ss58", return_value=valid_proxy
+        ) as mock_proxy_validation,
+    ):
+        mock_wallet_ask.return_value = Mock()
+
+        cli_manager.crowd_dissolve(
+            announce_only=False,
+            crowdloan_id=1,
+            network=None,
+            wallet_name="test_wallet",
+            wallet_path="/tmp/test",
+            wallet_hotkey="test_hotkey",
+            proxy=valid_proxy,
+            prompt=False,
+            wait_for_inclusion=True,
+            wait_for_finalization=False,
+            quiet=True,
+            verbose=False,
+            json_output=False,
+        )
+
+        mock_proxy_validation.assert_called_once_with(valid_proxy, False)
+        _, kwargs = mock_dissolve.dissolve_crowdloan.call_args
+        assert kwargs["announce_only"] is False
+
+
+def test_crowd_dissolve_threads_announce_only():
+    """crowd_dissolve with announce_only=True threads it into validation and downstream."""
+    cli_manager = CLIManager()
+    valid_proxy = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+
+    with (
+        patch.object(cli_manager, "verbosity_handler"),
+        patch.object(cli_manager, "wallet_ask") as mock_wallet_ask,
+        patch.object(cli_manager, "initialize_chain"),
+        patch.object(cli_manager, "_run_command"),
+        patch("bittensor_cli.cli.crowd_dissolve") as mock_dissolve,
+        patch.object(
+            cli_manager, "is_valid_proxy_name_or_ss58", return_value=valid_proxy
+        ) as mock_proxy_validation,
+    ):
+        mock_wallet_ask.return_value = Mock()
+
+        cli_manager.crowd_dissolve(
+            announce_only=True,
+            crowdloan_id=1,
+            network=None,
+            wallet_name="test_wallet",
+            wallet_path="/tmp/test",
+            wallet_hotkey="test_hotkey",
+            proxy=valid_proxy,
+            prompt=False,
+            wait_for_inclusion=True,
+            wait_for_finalization=False,
+            quiet=True,
+            verbose=False,
+            json_output=False,
+        )
+
+        mock_proxy_validation.assert_called_once_with(valid_proxy, True)
+        _, kwargs = mock_dissolve.dissolve_crowdloan.call_args
+        assert kwargs["announce_only"] is True
+
+
+def test_crowd_contribute_threads_announce_only():
+    """crowd_contribute with announce_only=True threads it into validation and downstream."""
+    cli_manager = CLIManager()
+    valid_proxy = "5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty"
+
+    with (
+        patch.object(cli_manager, "verbosity_handler"),
+        patch.object(cli_manager, "wallet_ask") as mock_wallet_ask,
+        patch.object(cli_manager, "initialize_chain"),
+        patch.object(cli_manager, "_run_command"),
+        patch("bittensor_cli.cli.crowd_contribute") as mock_contribute,
+        patch.object(
+            cli_manager, "is_valid_proxy_name_or_ss58", return_value=valid_proxy
+        ) as mock_proxy_validation,
+    ):
+        mock_wallet_ask.return_value = Mock()
+
+        cli_manager.crowd_contribute(
+            announce_only=True,
+            crowdloan_id=1,
+            amount=10.0,
+            network=None,
+            wallet_name="test_wallet",
+            wallet_path="/tmp/test",
+            wallet_hotkey="test_hotkey",
+            proxy=valid_proxy,
+            prompt=False,
+            wait_for_inclusion=True,
+            wait_for_finalization=False,
+            quiet=True,
+            verbose=False,
+            json_output=False,
+        )
+
+        mock_proxy_validation.assert_called_once_with(valid_proxy, True)
+        _, kwargs = mock_contribute.contribute_to_crowdloan.call_args
+        assert kwargs["announce_only"] is True
+
+
 # ============================================================================
 # Tests for root weights difference display
 # ============================================================================


### PR DESCRIPTION
## Summary

Reintroduces `--announce-only` for the stake, liquidity, and crowd command families. PR #899 removed the flag from 37 methods because it was accepted but never threaded to the extrinsic layer, so the UX falsely reported success (e.g. "Stake added") when only a `Proxy.announce` had been submitted. This brings it back properly for the 16 user-facing commands where it's meaningful, with honest success messaging and execution-time disclaimers. Closes #898 (scoped to these families per the issue discussion).

The underlying mechanic already exists — `sign_and_send_extrinsic(announce_only=True)` composes the `Proxy.announce`, records the `ProxyAnnouncements` entry, and prints the authoritative `btcli proxy execute --call-hash <hash>` line. This PR threads the flag through the CLI and command layers and fixes the per-command UX, following the pattern already used by `wallet transfer` and `proxy kill`.

## Scope (16 commands)

- **stake**: add, remove/unstake, unstake_all, move, transfer, swap
- **liquidity**: add, remove, modify
- **crowd**: create, contribute, withdraw, finalize, update, refund, dissolve

## Behavior under `--announce-only`

- Threads `announce_only` to the extrinsic layer (`sign_and_send_extrinsic` / `sign_and_send_batch_extrinsic`); does not re-implement the announce.
- Restores `is_valid_proxy_name_or_ss58(proxy, announce_only)`, enforcing that `--announce-only` requires `--proxy`.
- Replaces the misleading "completed" message with an explicit "Announcement submitted" status; the actionable `btcli proxy execute --call-hash` hint is printed by the extrinsic layer.
- Skips the post-success balance/stake re-fetch (nothing executed, so a delta would mislead and the RPC is wasted).
- Adds a disclaimer on slippage/summary tables (stake and crowd) noting figures reflect current chain state and may differ when the announced call executes. Liquidity has no slippage tables, so none was added.
- Adds an `announce_only` field to JSON output; the message does not claim completion.

## Decisions (open to maintainer feedback)

- **MEV guard**: under `--announce-only`, MEV protection is a no-op for the announcement (it applies at execution time via `proxy execute`). If MEV is on only by default it's silently disabled for the announce; it hard-errors only when `--mev-protection` is passed explicitly. Happy to switch to an always-hard-error policy if preferred.
- **Batching**: kept. A batch announces a single `Utility.batch_all` call hash covering N operations. By inspection, `proxy execute` reconstructs the stored call (including the `batch_all`), so a single batched announce should execute correctly — I wasn't able to confirm this against a live network, so please sanity-check that a batched announce executes as expected (call size, `batch_all` weight, and whether the proxy type permits `Utility.batch_all`).

## Open questions

- Confirm the batched-announce round-trip on a live network (above).
- Confirm the MEV-guard policy (silent-disable-on-default vs. always hard-error).
- Confirm the exact wording of the table disclaimer.

## Testing

- `tests/unit_tests/test_cli.py` passes (47); added `announce_only` forwarding tests for the affected commands and updated the prior `is_valid_proxy_name_or_ss58(proxy, False)` assertions to thread `announce_only`. The announce-requires-proxy `BadParameter` test and the transfer/batching forwarding tests remain green.
- `ruff format` / `ruff check` clean.
- Note: crypto/wallet-dependent suites weren't run locally (no prebuilt `bittensor-wallet` wheel on the dev environment); CI exercises them.
