### PR TITLE
feat(sudo): add min_childkey_take subnet hyperparameter

### DIFF
--- a/bittensor_cli/src/__init__.py
+++ b/bittensor_cli/src/__init__.py
@@ -639,6 +639,10 @@ HYPERPARAMS = {
     "max_allowed_uids": ("sudo_set_max_allowed_uids", RootSudoOnly.FALSE),
     "burn_increase_mult": ("sudo_set_burn_increase_mult", RootSudoOnly.FALSE),
     "burn_half_life": ("sudo_set_burn_half_life", RootSudoOnly.FALSE),
+    "min_childkey_take": (
+        "sudo_set_min_childkey_take_per_subnet",
+        RootSudoOnly.FALSE,
+    ),
 }
 
 # Maps a hyperparameter to a non-default pallet for sudo set calls. Empty by default
@@ -869,6 +873,12 @@ HYPERPARAMS_METADATA = {
         "side_effects": "Higher values make the burn price jump more sharply with each registration, raising the cost of rapid successive registrations.",
         "owner_settable": True,
         "docs_link": "docs.learnbittensor.org/subnets/subnet-hyperparameters#burnincreasemult",
+    },
+    "min_childkey_take": {
+        "description": "Minimum childkey take (%) required on this subnet. Settable by the subnet owner. Cannot be set below the global protocol minimum.",
+        "side_effects": "Child hotkeys on this subnet must set take at or above this value.",
+        "owner_settable": True,
+        "docs_link": "docs.learnbittensor.org/subnets/subnet-hyperparameters#minchildkeytake",
     },
 }
 

--- a/bittensor_cli/src/bittensor/utils.py
+++ b/bittensor_cli/src/bittensor/utils.py
@@ -852,6 +852,7 @@ def normalize_hyperparameters(
         "alpha_high": u16_normalized_float,
         "alpha_low": u16_normalized_float,
         "alpha_sigmoid_steepness": u16_normalized_float,
+        "min_childkey_take": u16_normalized_float,
         "min_burn": Balance.from_rao,
         "max_burn": Balance.from_rao,
     }

--- a/tests/unit_tests/test_hyperparams.py
+++ b/tests/unit_tests/test_hyperparams.py
@@ -9,6 +9,8 @@ NEW_HYPERPARAMS_826 = {
     "recycle_or_burn",
 }
 
+MIN_CHILDKEY_TAKE = "min_childkey_take"
+
 
 def test_new_hyperparams_in_hyperparams():
     for key in NEW_HYPERPARAMS_826:
@@ -47,3 +49,19 @@ def test_max_burn_is_owner_or_root_settable():
 
 def test_max_burn_metadata_owner_settable_true():
     assert HYPERPARAMS_METADATA["max_burn"]["owner_settable"] is True
+
+
+def test_min_childkey_take_in_hyperparams():
+    extrinsic, root_only = HYPERPARAMS[MIN_CHILDKEY_TAKE]
+    assert extrinsic == "sudo_set_min_childkey_take_per_subnet"
+    assert root_only is RootSudoOnly.FALSE
+
+
+def test_min_childkey_take_has_metadata():
+    required = {"description", "side_effects", "owner_settable", "docs_link"}
+    assert MIN_CHILDKEY_TAKE in HYPERPARAMS_METADATA
+    meta = HYPERPARAMS_METADATA[MIN_CHILDKEY_TAKE]
+    for field in required:
+        assert field in meta, f"{MIN_CHILDKEY_TAKE} metadata missing '{field}'"
+    assert meta["owner_settable"] is True
+    assert "#minchildkeytake" in meta["docs_link"]

--- a/tests/unit_tests/test_sudo_min_childkey_take.py
+++ b/tests/unit_tests/test_sudo_min_childkey_take.py
@@ -1,0 +1,55 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from bittensor_cli.src.bittensor.utils import float_to_u16
+
+from .conftest import COLDKEY_SS58
+
+MODULE = "bittensor_cli.src.commands.sudo"
+
+
+@pytest.mark.asyncio
+async def test_min_childkey_take_owner_composes_extrinsic(
+    mock_wallet, mock_subtensor, successful_receipt
+):
+    from bittensor_cli.src.commands.sudo import set_hyperparameter_extrinsic
+
+    take_u16 = float_to_u16(0.06)
+    direct_call = MagicMock(name="direct_call")
+    mock_subtensor.query = AsyncMock(return_value=COLDKEY_SS58)
+    mock_subtensor.substrate.metadata = MagicMock()
+    mock_subtensor.substrate.get_metadata_call_function = AsyncMock(
+        return_value={"fields": [{"name": "netuid"}, {"name": "take"}]}
+    )
+    mock_subtensor.substrate.compose_call = AsyncMock(return_value=direct_call)
+    mock_subtensor.sign_and_send_extrinsic = AsyncMock(
+        return_value=(True, "", successful_receipt)
+    )
+
+    with (
+        patch(f"{MODULE}.unlock_key", return_value=MagicMock(success=True)),
+        patch(f"{MODULE}.requires_bool", return_value=False),
+        patch(f"{MODULE}.print_extrinsic_id", new_callable=AsyncMock),
+    ):
+        success, err_msg, ext_id = await set_hyperparameter_extrinsic(
+            subtensor=mock_subtensor,
+            wallet=mock_wallet,
+            netuid=18,
+            proxy=None,
+            parameter="min_childkey_take",
+            value=take_u16,
+            wait_for_inclusion=False,
+            wait_for_finalization=False,
+            prompt=False,
+            normalize=False,
+        )
+
+    assert success is True
+    assert err_msg == ""
+    assert ext_id == "0x123-1"
+    mock_subtensor.substrate.compose_call.assert_awaited_once_with(
+        call_module="AdminUtils",
+        call_function="sudo_set_min_childkey_take_per_subnet",
+        call_params={"netuid": 18, "take": take_u16},
+        block_hash=mock_subtensor.substrate.last_block_hash,
+    )


### PR DESCRIPTION
## Summary

- Adds `min_childkey_take` as a subnet hyperparameter via the generic `btcli sudo set` / `btcli sudo get` flow (same pattern as `burn_half_life`, `max_burn`, etc.)
- Exposes `AdminUtils.sudo_set_min_childkey_take_per_subnet` from [Subtensor #2660](https://github.com/opentensor/subtensor/pull/2660)

## Usage

```bash
# VALUE column format from `btcli sudo get` (raw u16)
btcli sudo set --netuid 18 --param min_childkey_take --value 3932 --no-prompt

# normalized decimal (like burn_half_life)
btcli sudo set --netuid 18 --param min_childkey_take --value 0.06 --normalize --no-prompt

btcli sudo get --netuid 18
```

## Test plan

- [x] Registry tests: `tests/unit_tests/test_hyperparams.py`
- [x] Extrinsic compose test: `tests/unit_tests/test_sudo_min_childkey_take.py`
- [x] Full unit suite: 444 passed
- [ ] Manual smoke test on finney SN18 as subnet owner

## Notes

- No custom logic in `sudo.py` / `cli.py` — registry + `u16_normalized_float` display only
- Callable on-chain by subnet owner or root; client-side owner check matches other owner-settable hyperparams (`RootSudoOnly.FALSE`)