### PR TITLE
feat(wallet): add --coldkeys-only and natural sort to wallet list

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -2586,6 +2586,11 @@ class CLIManager:
         self,
         wallet_name: Optional[str] = Options.wallet_name,
         wallet_path: str = Options.wallet_path,
+        coldkeys_only: bool = typer.Option(
+            False,
+            "--coldkeys-only",
+            help="List coldkeys only; omit hotkeys from the output.",
+        ),
         quiet: bool = Options.quiet,
         verbose: bool = Options.verbose,
         json_output: bool = Options.json_output,
@@ -2596,11 +2601,13 @@ class CLIManager:
         The output display shows each wallet and its associated `ss58` addresses for the coldkey public key and any hotkeys. The output is presented in a hierarchical tree format, with each wallet as a root node and any associated hotkeys as child nodes. The `ss58` address (or an `<ENCRYPTED>` marker, for encrypted hotkeys) is displayed for each coldkey and hotkey that exists on the device.
 
         Upon invocation, the command scans the wallet directory and prints a list of all the wallets, indicating whether the
-        public keys are available (`?` denotes unavailable or encrypted keys).
+        public keys are available (`?` denotes unavailable or encrypted keys). Coldkeys and hotkeys are listed in natural
+        sort order (e.g. coldkey2 before coldkey10).
 
         # EXAMPLE
 
         [green]$[/green] btcli wallet list --path ~/.bittensor
+        [green]$[/green] btcli w list --coldkeys-only
 
         [bold]NOTE[/bold]: This command is read-only and does not modify the filesystem or the blockchain state. It is intended for use with the Bittensor CLI to provide a quick overview of the user's wallets.
         """
@@ -2613,6 +2620,7 @@ class CLIManager:
                 wallet.path,
                 json_output,
                 wallet_name=wallet_name,
+                coldkeys_only=coldkeys_only,
             )
         )
 

--- a/bittensor_cli/src/commands/wallets.py
+++ b/bittensor_cli/src/commands/wallets.py
@@ -2,6 +2,7 @@ import asyncio
 import hashlib
 import json
 import os
+import re
 from collections import defaultdict
 from enum import Enum
 from typing import Generator, Optional, Union
@@ -891,8 +892,26 @@ async def wallet_history(wallet: Wallet):
     console.print(table)
 
 
+def _natural_sort_key(name: str) -> list[Union[str, int]]:
+    """Sort names with numeric chunks ordered naturally (item2 before item10)."""
+    return [
+        int(part) if part.isdigit() else part.casefold()
+        for part in re.split(r"(\d+)", name)
+    ]
+
+
+def _hotkey_sort_key(hkey: Optional[Wallet]) -> tuple[bool, list[Union[str, int]]]:
+    if hkey is None:
+        return True, []
+    name = hkey.hotkey_str or hkey.name
+    return False, _natural_sort_key(name)
+
+
 async def wallet_list(
-    wallet_path: str, json_output: bool, wallet_name: Optional[str] = None
+    wallet_path: str,
+    json_output: bool,
+    wallet_name: Optional[str] = None,
+    coldkeys_only: bool = False,
 ):
     """Lists wallets."""
     wallets = utils.get_coldkey_wallets_for_path(wallet_path)
@@ -904,6 +923,8 @@ async def wallet_list(
         wallets = [wallet for wallet in wallets if wallet.name == wallet_name]
         if not wallets:
             print_error(f"Wallet '{wallet_name}' not found in dir: {wallet_path}")
+
+    wallets = sorted(wallets, key=lambda wallet: _natural_sort_key(wallet.name))
 
     root = Tree("Wallets")
     main_data_dict = {"wallets": []}
@@ -933,8 +954,13 @@ async def wallet_list(
             "hotkeys": wallet_hotkeys,
         }
         main_data_dict["wallets"].append(wallet_dict)
-        hotkeys = utils.get_hotkey_wallets_for_wallet(
-            wallet, show_nulls=True, show_encrypted=True
+        if coldkeys_only:
+            continue
+        hotkeys = sorted(
+            utils.get_hotkey_wallets_for_wallet(
+                wallet, show_nulls=True, show_encrypted=True
+            ),
+            key=_hotkey_sort_key,
         )
         for hkey in hotkeys:
             data = f"[bold red]Hotkey[/bold red][green] {hkey}[/green] (?)"

--- a/tests/unit_tests/test_wallet_list.py
+++ b/tests/unit_tests/test_wallet_list.py
@@ -1,0 +1,145 @@
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from .conftest import COLDKEY_SS58, HOTKEY_SS58
+
+MODULE = "bittensor_cli.src.commands.wallets"
+
+
+def _make_list_wallet(name: str = "coldkey1") -> MagicMock:
+    wallet = MagicMock()
+    wallet.name = name
+    wallet.coldkeypub_file.exists_on_device.return_value = True
+    wallet.coldkeypub_file.path = f"/tmp/{name}/coldkeypub.txt"
+    wallet.coldkeypub_file.is_encrypted.return_value = False
+    wallet.coldkeypub.ss58_address = COLDKEY_SS58
+    wallet.coldkeypub.crypto_type = 1
+    return wallet
+
+
+def _make_hotkey_wallet(name: str = "default") -> MagicMock:
+    hotkey = MagicMock()
+    hotkey.name = name
+    hotkey.hotkey_str = name
+    hotkey.get_hotkey.return_value.ss58_address = HOTKEY_SS58
+    hotkey.get_hotkey.return_value.crypto_type = 1
+    return hotkey
+
+
+def test_natural_sort_key_orders_numeric_suffixes():
+    from bittensor_cli.src.commands.wallets import _natural_sort_key
+
+    names = ["coldkey10", "coldkey2", "coldkey1", "zebra", "alice"]
+    assert sorted(names, key=_natural_sort_key) == [
+        "alice",
+        "coldkey1",
+        "coldkey2",
+        "coldkey10",
+        "zebra",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_wallet_list_sorts_coldkeys_naturally_in_json_output():
+    from bittensor_cli.src.commands.wallets import wallet_list
+
+    wallets = [
+        _make_list_wallet("coldkey10"),
+        _make_list_wallet("coldkey2"),
+        _make_list_wallet("coldkey1"),
+    ]
+
+    with (
+        patch(f"{MODULE}.utils.get_coldkey_wallets_for_path", return_value=wallets),
+        patch(f"{MODULE}.json_console") as mock_json,
+    ):
+        await wallet_list("/tmp/wallets", json_output=True, coldkeys_only=True)
+
+    payload = json.loads(mock_json.print.call_args[0][0])
+    assert [wallet["name"] for wallet in payload["wallets"]] == [
+        "coldkey1",
+        "coldkey2",
+        "coldkey10",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_wallet_list_sorts_hotkeys_naturally_in_json_output():
+    from bittensor_cli.src.commands.wallets import wallet_list
+
+    coldkey = _make_list_wallet()
+    hotkeys = [
+        _make_hotkey_wallet("hotkey10"),
+        _make_hotkey_wallet("hotkey2"),
+        _make_hotkey_wallet("hotkey1"),
+    ]
+
+    with (
+        patch(f"{MODULE}.utils.get_coldkey_wallets_for_path", return_value=[coldkey]),
+        patch(f"{MODULE}.utils.get_hotkey_wallets_for_wallet", return_value=hotkeys),
+        patch(f"{MODULE}.json_console") as mock_json,
+    ):
+        await wallet_list("/tmp/wallets", json_output=True, coldkeys_only=False)
+
+    payload = json.loads(mock_json.print.call_args[0][0])
+    assert [hk["name"] for hk in payload["wallets"][0]["hotkeys"]] == [
+        "hotkey1",
+        "hotkey2",
+        "hotkey10",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_wallet_list_coldkeys_only_skips_hotkey_lookup():
+    from bittensor_cli.src.commands.wallets import wallet_list
+
+    coldkey = _make_list_wallet()
+
+    with (
+        patch(f"{MODULE}.utils.get_coldkey_wallets_for_path", return_value=[coldkey]),
+        patch(f"{MODULE}.utils.get_hotkey_wallets_for_wallet") as mock_hotkeys,
+        patch(f"{MODULE}.console"),
+    ):
+        await wallet_list("/tmp/wallets", json_output=False, coldkeys_only=True)
+
+    mock_hotkeys.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_wallet_list_default_includes_hotkeys():
+    from bittensor_cli.src.commands.wallets import wallet_list
+
+    coldkey = _make_list_wallet()
+    hotkey = _make_hotkey_wallet()
+
+    with (
+        patch(f"{MODULE}.utils.get_coldkey_wallets_for_path", return_value=[coldkey]),
+        patch(
+            f"{MODULE}.utils.get_hotkey_wallets_for_wallet", return_value=[hotkey]
+        ) as mock_hotkeys,
+        patch(f"{MODULE}.console"),
+    ):
+        await wallet_list("/tmp/wallets", json_output=False, coldkeys_only=False)
+
+    mock_hotkeys.assert_called_once_with(coldkey, show_nulls=True, show_encrypted=True)
+
+
+@pytest.mark.asyncio
+async def test_wallet_list_coldkeys_only_json_has_empty_hotkeys():
+    from bittensor_cli.src.commands.wallets import wallet_list
+
+    coldkey = _make_list_wallet()
+
+    with (
+        patch(f"{MODULE}.utils.get_coldkey_wallets_for_path", return_value=[coldkey]),
+        patch(f"{MODULE}.utils.get_hotkey_wallets_for_wallet") as mock_hotkeys,
+        patch(f"{MODULE}.json_console") as mock_json,
+    ):
+        await wallet_list("/tmp/wallets", json_output=True, coldkeys_only=True)
+
+    mock_hotkeys.assert_not_called()
+    payload = json.loads(mock_json.print.call_args[0][0])
+    assert len(payload["wallets"]) == 1
+    assert payload["wallets"][0]["name"] == "coldkey1"
+    assert payload["wallets"][0]["hotkeys"] == []


### PR DESCRIPTION
## Summary

- Adds `--coldkeys-only` to `btcli wallet list` / `btcli w list` to show coldkeys without enumerating hotkeys (skips hotkey filesystem lookups)
- Sorts coldkeys and hotkeys in natural order by name (e.g. `coldkey2` before `coldkey10`, `hotkey90` after `hotkey8`)

## Usage

```bash
btcli w list
btcli w list --coldkeys-only
btcli wallet list --path ~/.bittensor --coldkeys-only
btcli w list --coldkeys-only --json-output
```

## Test plan

- [x] `tests/unit_tests/test_wallet_list.py` (6 tests)
- [x] Full unit suite: 450 passed

## Notes

- Logic lives in `wallets.wallet_list`; CLI adds the flag only (same pattern as other wallet commands)
- Natural sort applies to all `w list` output; `--coldkeys-only` only controls whether hotkeys are shown