### PR TITLE
Release/9.22.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 9.22.2 /2026-06-11
+
+## What's Changed
+
+* Pins cyscale to 0.4.0 to avoid accidental upgrades which break RootClaimable queries
+
+**Full Changelog**: https://github.com/latent-to/bittensor/compare/v9.22.1...v9.22.2
+
 ## 9.22.1 /2026-06-03
 
 ## What's Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "bittensor-cli"
-version = "9.22.1"
+version = "9.22.2"
 description = "Bittensor CLI"
 readme = "README.md"
 authors = [
@@ -37,7 +37,7 @@ dependencies = [
     "Jinja2",
     "PyYAML~=6.0",
     "rich>=15.0,<16.0",
-    "cyscale>=0.3.3,<1.0.0",
+    "cyscale==0.4.0",
     "typer~=0.26.0",
     "typing_extensions>4.0.0; python_version<'3.11'",
     "bittensor-wallet==4.1.0",


### PR DESCRIPTION
## 9.22.2 /2026-06-11

## What's Changed

* Pins cyscale to 0.4.0 to avoid accidental upgrades which break RootClaimable queries

**Full Changelog**: https://github.com/latent-to/bittensor/compare/v9.22.1...v9.22.2