### PR TITLE
Fix UnboundLocalError when --all is combined with --include-hotkeys (#1021)

### DIFF
--- a/bittensor_cli/cli.py
+++ b/bittensor_cli/cli.py
@@ -5670,6 +5670,12 @@ class CLIManager:
                 else:
                     print_error("Invalid hotkey ss58 address.")
                     return False
+                wallet = self.wallet_ask(
+                    wallet_name,
+                    wallet_path,
+                    wallet_hotkey,
+                    ask_for=[WO.NAME, WO.PATH],
+                )
             elif all_hotkeys:
                 wallet = self.wallet_ask(
                     wallet_name,


### PR DESCRIPTION
## Summary

Fixes #1021 — `btcli stake remove --all --include-hotkeys <ss58>` crashes with `UnboundLocalError: cannot access local variable 'wallet'`.

## Root cause

In `cli.py` around line 5658, the `stake_remove` handler's `unstake_all` branch routes by hotkey-resolution mode. Three of the four sub-branches call `self.wallet_ask(...)` to bind `wallet`:

| Sub-branch | `wallet_ask` called? |
|---|---|
| `include_hotkeys` | **No** ← the bug |
| `all_hotkeys` | Yes (L5674) |
| `hotkey_or_ss58` is valid ss58 | Yes (L5693) |
| `hotkey_or_ss58 == "all"` | Yes (L5701) |
| `hotkey_or_ss58` is a hotkey name | Yes (L5709) |

When `--include-hotkeys <ss58>` is used, `hotkey_ss58_address` gets set but `wallet` is never bound. The subsequent call at L5729 (`remove_stake.unstake_all(wallet=wallet, ...)`) then raises `UnboundLocalError`.

## Fix

Add the same `wallet_ask(ask_for=[WO.NAME, WO.PATH])` call already used by the adjacent `all_hotkeys` branch, since the hotkey is supplied via the `--include-hotkeys` ss58 (we don't need to ask for it).

## Verification

**Before:** `UnboundLocalError` traceback, no extrinsic submitted. Reproduced on `9.22.3` and `9.23.0` from PyPI, and confirmed still present on `main` HEAD (`350015a`, v9.23.1).

**After (this PR):** Tested live on mainnet (finney) by patching the fix into my local install and running:

```bash
btcli stake remove --wallet.name quantum_fund --netuid 4 --safe \
  --tolerance 0.05 --no-partial \
  --include-hotkeys 5HEj6CFUvmNDG915tz5yuYFfJsouk5AYVe7TRmdACofWyEqf \
  --subtensor.network finney --no-prompt --all
```

Result: extrinsic `8487314-15` finalized — SN4 fully unstaked from the delegate hotkey, +0.244 τ recovered. https://tao.app/extrinsic/8487314-15

## Notes

- Single-line-style change; no behavioral change for any non-`include_hotkeys` path.
- Doesn't add a test because the existing `stake_remove` flow has no test coverage I could extend cleanly — happy to add one in a follow-up if the maintainers point me at the right harness.
