### PR TITLE
Release 9.23.2: docs link fix + PyPI supersession notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
-> [!IMPORTANT]
-> **This repository is archived and no longer maintained.**
->
-> `btcli` is now part of the `bittensor` package (Bittensor 11), developed in the [subtensor monorepo](https://github.com/RaoFoundation/subtensor) (`sdk/python`). Existing `bittensor-cli` v9 releases remain installable from PyPI, but no further releases will be cut from this repository.
+# ⚠️ This package is superseded
+
+**`bittensor-cli` is superseded by the [`bittensor`](https://pypi.org/project/bittensor/) package (Bittensor 11), which includes `btcli`.** New projects should `pip install bittensor` instead. Development happens in the [subtensor monorepo](https://github.com/RaoFoundation/subtensor) (`sdk/python`), and documentation lives at [bittensor.com/docs](https://bittensor.com/docs).
+
+Existing `bittensor-cli` v9 releases remain installable from PyPI, but this repository is no longer maintained and no further feature releases will be cut from it.
+
+---
 
 <div align="center">
 
@@ -31,13 +34,13 @@
 
 The Bittensor CLI, `btcli`, is a powerful command line tool for the Bittensor platform. You can use it on any macOS, Linux or WSL terminal to manage all common operations like creating a wallet, registering a subnet or a neuron, delegating your TAO, viewing Senate proposals and voting for them, and much more. Help information can be invoked for every command and option with `--help` option.
 
-![btcli screenshot](./assets/btcli-screenshot.png)
+![btcli screenshot](https://raw.githubusercontent.com/RaoFoundation/btcli/main/assets/btcli-screenshot.png)
 
 ---
 
 ## Documentation
 
-Installation steps are described below. For a full documentation on how to use `btcli`, see the [Bittensor CLI section](https://docs.bittensor.com/btcli) on the developer documentation site.
+Installation steps are described below. For full documentation, see [bittensor.com/docs](https://bittensor.com/docs).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "bittensor-cli"
-version = "9.23.1"
+version = "9.23.2"
 description = "Bittensor CLI"
 readme = "README.md"
 authors = [
@@ -55,6 +55,8 @@ dev = [
 # more details can be found here
 homepage = "https://github.com/opentensor/btcli"
 Repository = "https://github.com/opentensor/btcli"
+Documentation = "https://bittensor.com/docs"
+Superseded-by = "https://pypi.org/project/bittensor/"
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Summary
- The PyPI page for `bittensor-cli` (ranks highly in search) has no indication the package is superseded: the notice landed after 9.23.1 shipped and uses GitHub-only `[!IMPORTANT]` alert syntax that PyPI renders as literal text. Rewritten in plain markdown with links to the `bittensor` package and bittensor.com/docs.
- `docs.bittensor.com` no longer resolves; the Documentation section now points at https://bittensor.com/docs (also added to `[project.urls]`).
- Screenshot URL absolutized so it renders on PyPI.
- Version bumped to 9.23.2 so a release can carry the new description to PyPI.

Replaces #1030 (branch renamed to `release/9.23.2` to satisfy the PR guard).

## Test plan
- [ ] Merge, dispatch `release.yml` with version `9.23.2`, confirm https://pypi.org/project/bittensor-cli/ shows the supersession notice.

Made with [Cursor](https://cursor.com)